### PR TITLE
Update local collector creation for spawning by default/no args

### DIFF
--- a/multi_clone.py
+++ b/multi_clone.py
@@ -85,9 +85,9 @@ def clone_lite_repo_with_slot(env_contents: str, slot_id, new_collector_instance
     os.system(f'screen -dmS {repo_name}')
     if not dev_mode:
         if new_collector_instance:
-            os.system(f'screen -S {repo_name} -p 0 -X stuff "./build.sh yes_collector\n"')
-        else:
             os.system(f'screen -S {repo_name} -p 0 -X stuff "./build.sh\n"')
+        else:
+            os.system(f'screen -S {repo_name} -p 0 -X stuff "./build.sh no_collector\n"')
     else:
         os.system(f'screen -S {repo_name} -p 0 -X stuff "./build-dev.sh\n"')
     print(f'Spawned screen session for docker containers {repo_name}') 


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #12

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [ ] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
`multi_clone.py` passes a `yes_collector` argument to force the creation of a local collector instance only when necessary.

### New expected behaviour
`multi_clone.py` will pass no arguments when a local collector instance needs to be spawned, and it will pass a `no_collector` argument when a new instance does not need to be created.

### Change logs

#### Changed
- `multi_clone.py` - updated local collector management

## Deployment Instructions
This PR is related to changes made to `snapshotter-lite-v2` here: https://github.com/PowerLoom/snapshotter-lite-v2/pull/41

The `fix/collector_profiles` branch of `snapshotter-lite-v2` should be used with these changes.
