### PR TITLE
hotfix: setting recommended_max_stream_pool_size to 20 for 1 CPU

### DIFF
--- a/multi_clone.py
+++ b/multi_clone.py
@@ -318,6 +318,8 @@ def main(data_market_choice: str):
         recommended_max_stream_pool_size = 40
     elif cpus >= 4:
         recommended_max_stream_pool_size = 100
+    else:
+        recommended_max_stream_pool_size = 20
     if os.getenv('MAX_STREAM_POOL_SIZE'):
         try:
             max_stream_pool_size = int(os.getenv('MAX_STREAM_POOL_SIZE', '0'))


### PR DESCRIPTION
Fixes #44

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and has been tested for major Python/NodeJS/Go versions.
- [x] I ran pre-commit checks against my changes.

### Current behaviour
Multi-node setup is failing for instances with 1 CPU

### New expected behaviour
Multi-node setup should work on instances with 1 CPU, too

#### Changed
Setting recommended_max_stream_pool_size to 20 for 1 CPU
