### PR TITLE
hotfix: explicitly convert contract and wallet addresses to checksum addresses

### DIFF
--- a/multi_clone.py
+++ b/multi_clone.py
@@ -298,6 +298,7 @@ def main(data_market_choice: str, non_interactive: bool = False):
         slot_contract = w3_new.eth.contract(address=slot_contract_address, abi=powerloom_nodes_abi)
     print(f'🔎 Against protocol state contract {slot_contract_address} found snapshotter state {slot_contract_address}')
     # Get all slots
+    wallet_holder_address = w3_new.to_checksum_address(wallet_holder_address)
     slot_ids = get_user_slots(slot_contract, wallet_holder_address)
     if not slot_ids:
         print('No slots found for wallet holder address')

--- a/multi_clone.py
+++ b/multi_clone.py
@@ -279,9 +279,13 @@ def main(data_market_choice: str, non_interactive: bool = False):
     except Exception as e:
         print(f"❌ Failed to fetch the latest block number. Your ISP/VPS region is not supported ⛔️ . Exception: {e}")
         sys.exit(1)
-    protocol_state_contract_old = w3_old.eth.contract(address=MIGRATION_INJECTIONS['PROTOCOL_STATE_OLD'], abi=protocol_state_abi)
-    protocol_state_contract = w3_new.eth.contract(address=MIGRATION_INJECTIONS['PROTOCOL_STATE_NEW'], abi=protocol_state_abi)
-    current_epoch_old = protocol_state_contract_old.functions.currentEpoch(DATA_MARKET_CHOICES_PROTOCOL_STATE[namespace]['DATA_MARKET_CONTRACT']).call()
+    protocol_state_old_address = w3_new.to_checksum_address(MIGRATION_INJECTIONS['PROTOCOL_STATE_OLD'])
+    protocol_state_new_address = w3_new.to_checksum_address(MIGRATION_INJECTIONS['PROTOCOL_STATE_NEW'])
+    data_market_address = w3_new.to_checksum_address(DATA_MARKET_CHOICES_PROTOCOL_STATE[namespace]['DATA_MARKET_CONTRACT'])
+
+    protocol_state_contract_old = w3_old.eth.contract(address=protocol_state_old_address, abi=protocol_state_abi)
+    protocol_state_contract = w3_new.eth.contract(address=protocol_state_new_address, abi=protocol_state_abi)
+    current_epoch_old = protocol_state_contract_old.functions.currentEpoch(data_market_address).call()
     latest_epoch_id_old = current_epoch_old[2]
     print('Latest epoch ID detected on old chain: ', latest_epoch_id_old)
     switchover_epoch_id = os.getenv('SWITCHOVER_EPOCH_ID', '1')
@@ -291,10 +295,12 @@ def main(data_market_choice: str, non_interactive: bool = False):
     if latest_epoch_id_old < int(switchover_epoch_id, 10):
         print('🎰 Using old chain for fetching slots...')
         slot_contract_address = protocol_state_contract_old.functions.snapshotterState().call()
+        slot_contract_address = w3_old.to_checksum_address(slot_contract_address)
         slot_contract = w3_old.eth.contract(address=slot_contract_address, abi=powerloom_nodes_abi)
     else:
         print('🎰 Using new chain for fetching slots...')
         slot_contract_address = protocol_state_contract.functions.snapshotterState().call()
+        slot_contract_address = w3_new.to_checksum_address(slot_contract_address)
         slot_contract = w3_new.eth.contract(address=slot_contract_address, abi=powerloom_nodes_abi)
     print(f'🔎 Against protocol state contract {slot_contract_address} found snapshotter state {slot_contract_address}')
     # Get all slots


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
When retrieving user slots, the `wallet_holder_address` is passed directly to the `get_user_slots function` without ensuring it's in the proper checksum format. This can cause issues when interacting with the Ethereum contract if the address case doesn't match the expected checksum format.


### New expected behaviour
The wallet_holder_address is now properly converted to checksum format using `w3_new.to_checksum_address()` before being passed to the `get_user_slots` function. This ensures consistent address formatting and prevents potential issues when interacting with Ethereum contracts.

### Change logs

#### Fixed
- Fixed potential address format issues by converting `wallet_holder_address` to proper checksum format before retrieving user slots

## Deployment Instructions
No special deployment instructions required. Standard deployment process applies.
