### PR TITLE
support `CONNECTION_REFRESH_INTERVAL_SEC` environment variable

### DIFF
--- a/multi_clone.py
+++ b/multi_clone.py
@@ -71,6 +71,7 @@ def env_file_template(
     stream_pool_health_check_interval: int = 30,
     local_collector_image_tag: str = 'latest',
     telegram_notification_cooldown: int = 300,
+    connection_refresh_interval_sec: int = 60,
 ) -> str:
     full_namespace = f'{powerloom_chain}-{namespace}-{source_chain}'
     docker_network_name = f"snapshotter-lite-v2-{full_namespace}"
@@ -99,6 +100,7 @@ DATA_MARKET_IN_REQUEST={data_market_in_request}
 LOCAL_COLLECTOR_IMAGE_TAG={local_collector_image_tag}
 TELEGRAM_REPORTING_URL={telegram_reporting_url}
 TELEGRAM_CHAT_ID={telegram_chat_id}
+CONNECTION_REFRESH_INTERVAL_SEC={connection_refresh_interval_sec}
 TELEGRAM_NOTIFICATION_COOLDOWN={telegram_notification_cooldown}
 """
 
@@ -120,6 +122,7 @@ def generate_env_file_contents(data_market_namespace: str, **kwargs) -> str:
         max_stream_pool_size=kwargs['max_stream_pool_size'],
         stream_pool_health_check_interval=kwargs['stream_pool_health_check_interval'],
         local_collector_image_tag=kwargs['local_collector_image_tag'],
+        connection_refresh_interval_sec=kwargs['connection_refresh_interval_sec'],
     )
 
 def run_snapshotter_lite_v2(deploy_slots: list, data_market_contract_number: int, data_market_namespace: str, **kwargs):
@@ -157,6 +160,7 @@ def run_snapshotter_lite_v2(deploy_slots: list, data_market_contract_number: int
             stream_pool_health_check_interval=kwargs['stream_pool_health_check_interval'],
             local_collector_image_tag=kwargs['local_collector_image_tag'],
             slot_id=slot_id,
+            connection_refresh_interval_sec=kwargs['connection_refresh_interval_sec'],
         )
         with open(f'.env-{full_namespace}', 'w+') as f:
             f.write(env_file_contents)
@@ -364,6 +368,7 @@ def main(data_market_choice: str, non_interactive: bool = False):
         max_stream_pool_size=max_stream_pool_size,
         stream_pool_health_check_interval=os.getenv('STREAM_POOL_HEALTH_CHECK_INTERVAL', 120),
         local_collector_image_tag=local_collector_image_tag,
+        connection_refresh_interval_sec=os.getenv('CONNECTION_REFRESH_INTERVAL_SEC', 60),
     )
 
 


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #52 

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
Refer issue description

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
Refer issue description

### Change logs

#### Added
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->
* Support for `CONNECTION_REFRESH_INTERVAL_SEC` to be passed to underlying lite node setup

<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
Test with the following combinations of the lite node branch and local collector image tag.

PS: Do not configure `latest` against local collector image tag since the merged PR https://github.com/PowerLoom/snapshotter-lite-local-collector/pull/36 has not yet been tagged as that.

```bash
LITE_NODE_BRANCH=main  # or experimental
LOCAL_COLLECTOR_IMAGE_TAG=experimental # or main
```
