### PR TITLE
Update GitHub Actions workflow to use Ubuntu 22.04 and standardize architecture naming to `amd64` for consistency.

### DIFF
--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             platform: linux
-            arch: x86_64
+            arch: amd64
           - os: macos-latest
             platform: macos
             arch: arm64
@@ -116,11 +116,11 @@ jobs:
 
           ### Installation
 
-          #### Linux (x86_64)
+          #### Linux (AMD64)
           ```bash
-          wget https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/powerloom-snapshotter-cli-linux-x86_64
-          chmod +x powerloom-snapshotter-cli-linux-x86_64
-          sudo mv powerloom-snapshotter-cli-linux-x86_64 /usr/local/bin/powerloom-snapshotter-cli
+          wget https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/powerloom-snapshotter-cli-linux-amd64
+          chmod +x powerloom-snapshotter-cli-linux-amd64
+          sudo mv powerloom-snapshotter-cli-linux-amd64 /usr/local/bin/powerloom-snapshotter-cli
           ```
 
           #### Linux (ARM64)

--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -19,13 +19,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             platform: linux
             arch: x86_64
           - os: macos-latest
             platform: macos
             arch: arm64
-          - os: ubuntu-24.04-arm  # GitHub's native ARM64 runner
+          - os: ubuntu-22.04-arm  # GitHub's native ARM64 runner
             platform: linux
             arch: arm64
 

--- a/README.md
+++ b/README.md
@@ -635,14 +635,14 @@ uv build
 ```
 
 This will create:
-- A wheel file in `dist/powerloom_snapshotter_cli-0.1.0-py3-none-any.whl`
-- A source distribution in `dist/powerloom_snapshotter_cli-0.1.0.tar.gz`
+- A wheel file in `dist/powerloom_snapshotter_cli-0.1.1-py3-none-any.whl`
+- A source distribution in `dist/powerloom_snapshotter_cli-0.1.1.tar.gz`
 
 ### Testing the Build
 
 ```bash
 # Install the CLI globally with uv (use --force to update existing installation)
-uv tool install --force --from dist/powerloom_snapshotter_cli-0.1.0-py3-none-any.whl powerloom-snapshotter-cli
+uv tool install --force --from dist/powerloom_snapshotter_cli-0.1.1-py3-none-any.whl powerloom-snapshotter-cli
 
 # Or for development, install in editable mode
 uv tool install --editable --from . powerloom-snapshotter-cli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "powerloom-snapshotter-cli"
-version = "0.1.0"
+version = "0.1.1"
 description = "CLI tool for deploying and managing Powerloom Snapshotter nodes"
 authors = [{name = "Powerloom Protocol", email = "hello@powerloom.io"}]
 readme = "PYPI_README.md"

--- a/snapshotter_cli/__init__.py
+++ b/snapshotter_cli/__init__.py
@@ -1,3 +1,3 @@
 """Powerloom Snapshotter Node Management CLI"""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "powerloom-snapshotter-cli"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "psutil" },


### PR DESCRIPTION
Fixes #62 

```yaml
# .github/workflows/build-cli-binaries.yml
# Linux AMD64
- os: ubuntu-22.04  # Changed from ubuntu-latest
  platform: linux
  arch: amd64       # Changed from x86_64 for consistency

# Linux ARM64
- os: ubuntu-22.04-arm  # Changed from ubuntu-24.04-arm
  platform: linux
  arch: arm64
```

### Why This Works
- Glibc maintains backward compatibility
- Binary built with glibc 2.35 (Ubuntu 22.04) works on glibc 2.38 (Ubuntu 24.04)
- Ensures compatibility with all Ubuntu versions ≥ 22.04

### Testing
- [x] Verified glibc versions: Ubuntu 22.04 (2.35), Ubuntu 24.04 (2.38)
- [x] Build binary on Ubuntu 22.04
- [x] Test on Ubuntu 22.04
- [x] Test on Ubuntu 24.04