### PR TITLE
Fix CLI deployment issues and improve UX

### DIFF
--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -798,8 +798,8 @@ def deploy(
                 elif market_name == "UNISWAPV2":
                     data_market_number = "2"
                 else:
-                    # Default to 2 for unknown markets
-                    data_market_number = "2"
+                    # Default to 1 for unknown markets
+                    data_market_number = "1"
 
                 # Add data market contract number
                 base_args = (

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -784,11 +784,33 @@ def deploy(
                 continue
 
             for idx, slot_id_val in enumerate(deploy_slots):
-                build_sh_args_for_instance = (
+                # Build base args for build.sh
+                base_args = (
                     "--skip-credential-update"
                     if idx == 0
                     else "--no-collector --skip-credential-update"
                 )
+
+                # Determine data market contract number based on market name
+                market_name = market_conf_obj.name.upper()
+                if market_name == "AAVEV3":
+                    data_market_number = "1"
+                elif market_name == "UNISWAPV2":
+                    data_market_number = "2"
+                else:
+                    # Default to 2 for unknown markets
+                    data_market_number = "2"
+
+                # Add data market contract number
+                base_args = (
+                    f"{base_args} --data-market-contract-number {data_market_number}"
+                )
+
+                # Add --devnet flag if deploying to devnet
+                if selected_powerloom_chain_name_upper == "DEVNET":
+                    build_sh_args_for_instance = f"--devnet {base_args}"
+                else:
+                    build_sh_args_for_instance = base_args
 
                 console.print(
                     f"   🔩 Deploying slot {slot_id_val} for market {market_conf_obj.name} (Source RPC: {source_rpc_url})",

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -259,7 +259,14 @@ def deploy(
                 )
                 raise typer.Exit(1)
         else:
-            all_powerloom_chains_from_config = cli_context.markets_config
+            # Sort chains to prioritize MAINNET first
+            all_powerloom_chains_from_config = sorted(
+                cli_context.markets_config,
+                key=lambda x: (
+                    x.powerloomChain.name.upper() != "MAINNET",
+                    x.powerloomChain.name.upper(),
+                ),
+            )
             if not all_powerloom_chains_from_config:
                 console.print(
                     "❌ No Powerloom chains found in the remote configuration. Cannot proceed.",
@@ -268,7 +275,7 @@ def deploy(
                 raise typer.Exit(1)
 
             chain_list_display = "\n".join(
-                f"[bold green]{i+1}.[/] [cyan]{chain.powerloomChain.name}[/]"
+                f"[bold green]{i+1}.[/] [cyan]{chain.powerloomChain.name.title()}[/]"
                 for i, chain in enumerate(all_powerloom_chains_from_config)
             )
             panel = Panel(

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -99,9 +99,25 @@ def configure_command(
             )
             raise typer.Exit(1)
     else:
-        chain_list = sorted(cli_context.available_environments)
-        for i, chain in enumerate(chain_list, 1):
-            console.print(f"[bold green]{i}.[/] [cyan]{chain}[/]")
+        # Sort chains to prioritize MAINNET first
+        chain_list = sorted(
+            cli_context.available_environments,
+            key=lambda x: (x.upper() != "MAINNET", x.upper()),
+        )
+
+        # Display chains in a panel like deployment command
+        chain_list_display = "\n".join(
+            f"[bold green]{i}.[/] [cyan]{chain.title()}[/]"
+            for i, chain in enumerate(chain_list, 1)
+        )
+        panel = Panel(
+            chain_list_display,
+            title="[bold blue]Select Powerloom Chain[/]",
+            border_style="blue",
+            padding=(1, 2),
+        )
+        console.print(panel)
+
         while True:
             chain_input = Prompt.ask("👉 Select Powerloom chain (number or name)")
             if chain_input.isdigit():

--- a/snapshotter_cli/commands/identity.py
+++ b/snapshotter_cli/commands/identity.py
@@ -75,7 +75,7 @@ def list_identities(ctx: typer.Context):
         header_style="bold blue",
         title_style="bold cyan",
     )
-    table.add_column("Chain", style="magenta")
+    table.add_column("Powerloom Chain", style="magenta")
     table.add_column("Market", style="cyan")
     table.add_column("Source Chain", style="green")
     table.add_column("Status", style="yellow")

--- a/snapshotter_cli/commands/shell.py
+++ b/snapshotter_cli/commands/shell.py
@@ -163,17 +163,19 @@ def get_missing_parameters(
                         )
                     elif param_name == "chain":
                         # Get available chains from CLI context
-                        available_chains = ["DEVNET", "MAINNET"]
+                        available_chains = ["MAINNET", "DEVNET"]
                         if parent_ctx and hasattr(parent_ctx, "obj") and parent_ctx.obj:
                             cli_context = parent_ctx.obj
                             if hasattr(cli_context, "available_environments"):
+                                # Sort chains to prioritize MAINNET first
                                 available_chains = sorted(
-                                    cli_context.available_environments
+                                    cli_context.available_environments,
+                                    key=lambda x: (x.upper() != "MAINNET", x.upper()),
                                 )
 
                         # Show available chains
                         console.print(
-                            f"\nAvailable chains: {', '.join(available_chains)}"
+                            f"\nAvailable chains: {', '.join([c.title() for c in available_chains])}"
                         )
 
                         while True:
@@ -188,7 +190,7 @@ def get_missing_parameters(
                                 break
 
                             console.print(
-                                f"❌ Invalid selection. Please choose from: {', '.join(available_chains)}",
+                                f"❌ Invalid selection. Please choose from: {', '.join([c.title() for c in available_chains])}",
                                 style="red",
                             )
                     elif param_name == "market":

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -135,9 +135,9 @@ def deploy_snapshotter_instance(
 
     instance_subpath = f"{norm_pl_chain_name}/{norm_market_name}_{norm_source_chain_name_for_path}/slot-{slot_id}"
     instance_dir = SNAPSHOTTER_LITE_V2_DIR / instance_subpath
-    # e.g., MAINNET-UNISWAPV2-ETH
+    # e.g., mainnet-UNISWAPV2-ETH (lowercase chain name to match build.sh expectations)
     env_file_suffix = (
-        f"{pl_chain_name_upper}-{market_name_upper}-{source_chain_prefix_upper}"
+        f"{norm_pl_chain_name}-{market_name_upper}-{source_chain_prefix_upper}"
     )
     env_file_path = instance_dir / f".env-{env_file_suffix}"
 


### PR DESCRIPTION
This PR addresses critical bug #72 and deployment issues while enhancing the user experience with improved chain selection displays.

### Changes

#### 🐛 Bug Fixes
1. **ENV File Case Mismatch (#72)**
   - Fixed deployment failure where CLI generated `.env-MAINNET-UNISWAPV2-ETH` but `build.sh` expected `.env-mainnet-UNISWAPV2-ETH`
   - Updated `deployment.py` to use lowercase chain names in env file suffix to match `build.sh` expectations

2. **Missing Deployment Flags**
   - Added `--devnet` flag for devnet deployments
   - Added `--data-market-contract-number` flag with proper mapping (1=AAVEV3, 2=UNISWAPV2)
   - Changed default market number to 1 for unknown markets (more conservative approach)

#### ✨ UX Improvements
- **Prioritized Mainnet**: Reordered chain selection to show Mainnet first across all commands
- **Title case display**: Changed chain display from `MAINNET`/`DEVNET` to `Mainnet`/`Devnet` for better readability
- **Consistent UI**: Unified chain selection interface between `configure` and `deploy` commands using Panel display
- **Shell mode updates**: Applied same improvements to interactive shell mode

### Files Modified
- `snapshotter_cli/utils/deployment.py` - Fixed env file naming
- `snapshotter_cli/cli.py` - Added deployment flags, chain sorting, and title case display
- `snapshotter_cli/commands/configure.py` - Added Panel UI and chain sorting
- `snapshotter_cli/commands/shell.py` - Updated chain display and ordering

### Testing
The fixes ensure that:
- Deployed snapshotter nodes can successfully start by resolving the env filename mismatch
- Devnet deployments receive the correct `--devnet` flag
- Each market deployment gets the appropriate data market contract number