### PR TITLE
Streamline Configuration by Auto-Setting Technical Parameters

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -59,7 +59,7 @@ jobs:
       run: uv run mypy snapshotter_cli/ || true  # Allow mypy to fail for now
 
     - name: Run tests
-      run: uv run pytest tests/ -v || echo "No tests found, continuing..."
+      run: uv run pytest tests/ -v
 
     - name: Test CLI
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Configuration update defaults** - MAX_STREAM_POOL_SIZE and CONNECTION_REFRESH_INTERVAL_SEC now properly show existing values when updating configuration
+
 ### Changed
 - **Smart changelog display** - Shows "What's New" only once per version update to reduce notification fatigue
 - **Enhanced markdown formatting** - Bold text in changelog now renders properly in terminal output
+- **Connection refresh interval default** - Changed from 75 to 60 seconds for better performance
 
 ## [v0.1.3] - 2025-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Enhanced markdown formatting** - Bold text in changelog now renders properly in terminal output
 - **Connection refresh interval default** - Changed from 75 to 60 seconds for better performance
 
+### Added
+- **Conditional Telegram cooldown prompt** - Only asks for notification cooldown when Telegram chat ID is provided
+
 ### Improved
-- **Configuration UX** - Reduced from 9+ prompts to 6 essential ones, auto-setting technical parameters with smart defaults
+- **Configuration UX** - Reduced from 9+ prompts to 6-7 essential ones, auto-setting technical parameters with smart defaults
 
 ## [v0.1.3] - 2025-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Configuration update defaults** - MAX_STREAM_POOL_SIZE and CONNECTION_REFRESH_INTERVAL_SEC now properly show existing values when updating configuration
+- **Configuration value preservation (#76)** - Technical parameters now properly preserve existing values when updating configuration
 
 ### Changed
+- **Streamlined configuration** - Removed prompts for TELEGRAM_REPORTING_URL, MAX_STREAM_POOL_SIZE, and CONNECTION_REFRESH_INTERVAL_SEC
 - **Smart changelog display** - Shows "What's New" only once per version update to reduce notification fatigue
 - **Enhanced markdown formatting** - Bold text in changelog now renders properly in terminal output
 - **Connection refresh interval default** - Changed from 75 to 60 seconds for better performance
+
+### Improved
+- **Configuration UX** - Reduced from 9+ prompts to 6 essential ones, auto-setting technical parameters with smart defaults
 
 ## [v0.1.3] - 2025-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Powerloom Snapshotter CLI and setup tools will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Smart changelog display** - Shows "What's New" only once per version update to reduce notification fatigue
+
 ## [v0.1.3] - 2025-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Smart changelog display** - Shows "What's New" only once per version update to reduce notification fatigue
+- **Enhanced markdown formatting** - Bold text in changelog now renders properly in terminal output
 
 ## [v0.1.3] - 2025-08-09
 

--- a/CLI_DOCUMENTATION.md
+++ b/CLI_DOCUMENTATION.md
@@ -9,10 +9,7 @@
   - [configure](#configure)
   - [deploy](#deploy)
   - [list](#list)
-  - [stop](#stop)
-  - [restart](#restart)
-  - [cleanup](#cleanup)
-  - [logs](#logs)
+  - [status](#status)
   - [diagnose](#diagnose)
   - [identity](#identity)
   - [shell](#shell)
@@ -37,10 +34,11 @@ Both commands are equivalent and can be used interchangeably.
 
 - 🚀 **Easy Configuration**: Set up credentials and settings for different chain/market combinations
 - 📦 **Multi-Instance Management**: Deploy and manage multiple snapshotter instances
-- 🔍 **Instance Monitoring**: View status, logs, and diagnostics for running instances
+- 🔍 **Instance Monitoring**: View status and diagnostics for running instances
 - 🐚 **Interactive Shell**: Fast command execution with history support
 - 🔐 **Secure Credential Storage**: Namespaced environment files for different configurations
 - 🏗️ **Identity Management**: Generate and manage signer identities
+- 📊 **Status Monitoring**: Check status of deployed instances
 
 ## Installation
 
@@ -113,7 +111,7 @@ powerloom-snapshotter-cli shell
 powerloom-snapshotter> configure
 powerloom-snapshotter> deploy
 powerloom-snapshotter> list
-powerloom-snapshotter> logs --follow
+powerloom-snapshotter> status
 ```
 
 **Note:** After installation with `uv sync`, commands are available through `uv run`. For direct terminal access without the `uv run` prefix, use `uv tool install`.
@@ -137,9 +135,9 @@ If you prefer to run individual commands:
    powerloom-snapshotter-cli list
    ```
 
-4. **View logs:**
+4. **Check status:**
    ```bash
-   powerloom-snapshotter-cli logs --env devnet --market uniswapv2
+   powerloom-snapshotter-cli status --env devnet --market uniswapv2
    ```
 
 ## Interactive Shell Mode (Recommended)
@@ -184,12 +182,11 @@ powerloom-snapshotter> deploy --env devnet --market uniswapv2
 powerloom-snapshotter> list
 [Shows running instances...]
 
-powerloom-snapshotter> logs --env devnet --market uniswapv2 --follow
-[Real-time logs...]
-^C  # Press Ctrl+C to stop following logs
+powerloom-snapshotter> status --env devnet --market uniswapv2
+[Shows status of instances...]
 
-powerloom-snapshotter> stop --env devnet --market uniswapv2
-[Stops instances...]
+powerloom-snapshotter> diagnose --clean
+[Runs diagnostics and cleanup...]
 
 powerloom-snapshotter> exit
 Goodbye!
@@ -270,113 +267,49 @@ powerloom-snapshotter-cli deploy --env devnet --market uniswapv2 --market aavev3
 
 ### list
 
-List all active snapshotter instances.
+Display available Powerloom chains and their data markets.
 
 ```bash
 powerloom-snapshotter-cli list
 ```
 
 **Output includes:**
-- Instance name
-- Status (Active/Inactive)
+- Available Powerloom chains (with Chain ID and RPC)
+- Data markets for each chain
+- Market contracts and configurations
+- Source chains for each market
+
+### status
+
+Show status of deployed snapshotter instances (screen sessions and Docker containers).
+
+```bash
+powerloom-snapshotter-cli status [OPTIONS]
+```
+
+**Options:**
+- `--env, -e`: Filter by Powerloom chain environment name
+- `--market, -m`: Filter by data market name
+
+**Examples:**
+```bash
+# Check status of all instances
+powerloom-snapshotter-cli status
+
+# Check status for specific chain/market
+powerloom-snapshotter-cli status --env devnet --market uniswapv2
+```
+
+**Output includes:**
+- Powerloom chain and data market
+- Slot ID
+- Screen session name and PID
+- Screen status
 - Docker container status
-- Process details
-
-### stop
-
-Stop snapshotter instances.
-
-```bash
-powerloom-snapshotter-cli stop [OPTIONS]
-```
-
-**Options:**
-- `--env, -e`: Filter by Powerloom chain
-- `--market, -m`: Filter by data market
-- `--slot, -s`: Stop specific slot
-
-**Examples:**
-```bash
-# Stop all instances
-powerloom-snapshotter-cli stop
-
-# Stop all instances for a chain
-powerloom-snapshotter-cli stop --env devnet
-
-# Stop specific market instances
-powerloom-snapshotter-cli stop --env devnet --market uniswapv2
-
-# Stop specific slot
-powerloom-snapshotter-cli stop --env devnet --market uniswapv2 --slot 123
-```
-
-### restart
-
-Restart snapshotter instances (stop and start).
-
-```bash
-powerloom-snapshotter-cli restart [OPTIONS]
-```
-
-**Options:**
-- `--env, -e`: Filter by Powerloom chain
-- `--market, -m`: Filter by data market
-- `--slot, -s`: Restart specific slot
-
-### cleanup
-
-Remove stopped instances and clean up resources.
-
-```bash
-powerloom-snapshotter-cli cleanup [OPTIONS]
-```
-
-**Options:**
-- `--env, -e`: Filter by Powerloom chain
-- `--market, -m`: Filter by data market
-- `--slot, -s`: Cleanup specific slot
-- `--force, -f`: Skip confirmation prompts
-
-**Example:**
-```bash
-# Cleanup with confirmation
-powerloom-snapshotter-cli cleanup --env devnet --market uniswapv2
-
-# Force cleanup without confirmation
-powerloom-snapshotter-cli cleanup --force
-```
-
-### logs
-
-View logs for snapshotter instances.
-
-```bash
-powerloom-snapshotter-cli logs [OPTIONS]
-```
-
-**Options:**
-- `--env, -e`: Powerloom chain name
-- `--market, -m`: Data market name
-- `--slot, -s`: Specific slot ID
-- `--lines, -n`: Number of lines to show (default: 50)
-- `--follow, -f`: Follow log output
-- `--container, -c`: Container to show logs for (core-api or snapshotter)
-
-**Examples:**
-```bash
-# View recent logs
-powerloom-snapshotter-cli logs --env devnet --market uniswapv2
-
-# Follow logs in real-time
-powerloom-snapshotter-cli logs --env devnet --market uniswapv2 --follow
-
-# View specific container logs
-powerloom-snapshotter-cli logs --env devnet --market uniswapv2 --container core-api
-```
 
 ### diagnose
 
-Run diagnostics on the system and check requirements.
+Run diagnostics on the system and optionally clean up existing deployments.
 
 ```bash
 powerloom-snapshotter-cli diagnose [OPTIONS]
@@ -384,7 +317,7 @@ powerloom-snapshotter-cli diagnose [OPTIONS]
 
 **Options:**
 - `--clean, -c`: Clean up existing deployments
-- `--force, -f`: Force cleanup without confirmation
+- `--force, -f`: Force cleanup without confirmation (use with --clean)
 
 **Diagnostics include:**
 - Python version check
@@ -492,8 +425,8 @@ screen -ls
 # Quit specific session
 screen -X -S session_name quit
 
-# Or use cleanup command
-powerloom-snapshotter-cli cleanup --force
+# Or use diagnose command with cleanup
+powerloom-snapshotter-cli diagnose --clean --force
 ```
 
 #### 5. "ABI files not found"

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -47,8 +47,8 @@ powerloom-snapshotter-cli deploy
 # Check status of running instances
 powerloom-snapshotter-cli status
 
-# View logs
-powerloom-snapshotter-cli logs --follow
+# View detailed status
+powerloom-snapshotter-cli status --env mainnet --market uniswapv2
 ```
 
 ## Available Commands
@@ -56,9 +56,7 @@ powerloom-snapshotter-cli logs --follow
 - `configure` - Set up chain and market-specific credentials
 - `deploy` - Deploy a new snapshotter instance
 - `status` - View status of deployed instances
-- `logs` - Display snapshotter logs
-- `stop` - Stop running instances
-- `cleanup` - Remove stopped instances
+- `list` - Display available chains and data markets
 - `diagnose` - Run system diagnostics
 - `identity` - Manage multiple configurations
 - `shell` - Start interactive mode

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ powerloom-snapshotter-cli shell
 powerloom-snapshotter> configure
 powerloom-snapshotter> deploy
 powerloom-snapshotter> list
-powerloom-snapshotter> logs --follow
+powerloom-snapshotter> status
 ```
 
 💡 **Why use shell mode?** The CLI has a startup time for each command. Shell mode eliminates this delay, giving you instant command execution!
@@ -52,7 +52,7 @@ The CLI has been enhanced with several UX improvements:
 - **📋 Integrated Changelog**: View latest changes on shell startup, full changelog with `changelog` command
 - **Easy Configuration**: Set up credentials once for each chain/market combination
 - **Simple Deployment**: Deploy multiple nodes with a single command
-- **Instance Management**: Start, stop, restart, and cleanup nodes easily
+- **Instance Management**: Deploy and monitor snapshotter nodes easily
 - **Cross-Platform**: Pre-built binaries for Linux (x86_64, ARM64) and macOS (ARM64)
 - **Native ARM64 Builds**: Uses GitHub's native ARM64 runners for 4x faster builds
 - **Command History**: Navigate previous commands with arrow keys in shell mode

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import traceback
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -9,6 +10,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.tree import Tree
 
+from snapshotter_cli.utils.changelog import display_changelog
 from snapshotter_cli.utils.console import Prompt, console
 
 from . import __version__, get_version_string
@@ -25,6 +27,7 @@ from .utils.deployment import (
     run_git_command,
 )
 from .utils.docker_utils import get_docker_container_status_for_instance
+from .utils.evm import fetch_owned_slots
 from .utils.models import (
     ChainConfig,
     ChainMarketData,
@@ -105,8 +108,6 @@ def version_callback(value: bool):
 def changelog_callback(value: bool):
     """Show changelog and exit."""
     if value:
-        from snapshotter_cli.utils.changelog import display_changelog
-
         display_changelog()
         raise typer.Exit()
 
@@ -167,8 +168,6 @@ def load_default_config(
         ctx.obj = cli_obj
     except Exception as e:
         console.print(f"🚨 Error in load_default_config: {e}", style="bold red")
-        import traceback
-
         console.print(traceback.format_exc())
         raise typer.Exit(1)
 
@@ -187,7 +186,7 @@ app.add_typer(identity_app, name="identity")
 @app.command()
 def shell(ctx: typer.Context):
     """Start an interactive shell session for faster command execution."""
-    shell_command(ctx)
+    shell_command(ctx, app)
 
 
 # class Environment(str, Enum):
@@ -532,8 +531,6 @@ def deploy(
             protocol_state_contract_address = (
                 first_market.powerloomProtocolStateContractAddress
             )
-
-            from .utils.evm import fetch_owned_slots
 
             fetched_slots_result = fetch_owned_slots(
                 wallet_address=final_wallet_address,

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -905,12 +905,12 @@ def status(
     if environment:
         console.print(
             f"🔍 Filtering for environment: [bold cyan]{environment}[/bold cyan]",
-            style="info",
+            style="dim",
         )
     if data_market:
         console.print(
             f"🔍 Filtering for data market: [bold cyan]{data_market}[/bold cyan]",
-            style="info",
+            style="dim",
         )
 
     all_screen_sessions = list_snapshotter_screen_sessions()

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from typing import Dict, Optional
 
+import psutil
 import typer
 from dotenv import dotenv_values
 from rich.panel import Panel
@@ -235,8 +236,6 @@ def configure_command(
         )
 
     # Calculate recommended max stream pool size based on CPU count
-    import psutil
-
     cpus = psutil.cpu_count(logical=True)
     if cpus >= 2 and cpus < 4:
         recommended_max_stream_pool_size = 40

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -272,35 +272,33 @@ def configure_command(
         "👉 Enter Telegram chat ID (optional)",
         default=existing_env_vars.get("TELEGRAM_CHAT_ID", ""),
     )
-    final_telegram_url = telegram_reporting_url or Prompt.ask(
-        "👉 Enter Telegram reporting URL (optional)",
-        default=existing_env_vars.get("TELEGRAM_REPORTING_URL", ""),
+    # Don't prompt for Telegram reporting URL - use existing or default
+    final_telegram_url = (
+        telegram_reporting_url
+        or existing_env_vars.get("TELEGRAM_REPORTING_URL")
+        or "https://tg-testing.powerloom.io/"
     )
 
-    # Prompt user for max stream pool size
-    # Use existing value as default if updating, otherwise use recommended value
-    default_max_stream_pool_size = existing_env_vars.get(
-        "MAX_STREAM_POOL_SIZE", str(recommended_max_stream_pool_size)
+    # Don't prompt for max stream pool size - use existing or recommended value
+    final_max_stream_pool_size = (
+        max_stream_pool_size
+        or existing_env_vars.get("MAX_STREAM_POOL_SIZE")
+        or str(recommended_max_stream_pool_size)
     )
-    final_max_stream_pool_size = max_stream_pool_size or Prompt.ask(
-        "👉 Enter max stream pool size for local collector",
-        default=default_max_stream_pool_size,
-    )
+
+    # Ensure it doesn't exceed recommended value
     if int(final_max_stream_pool_size) > recommended_max_stream_pool_size:
         console.print(
-            f"⚠️ MAX_STREAM_POOL_SIZE is greater than the recommended {recommended_max_stream_pool_size} for {cpus} logical CPUs, this may cause instability! Choosing the recommended value.",
-            style="bold red",
+            f"⚠️ MAX_STREAM_POOL_SIZE ({final_max_stream_pool_size}) is greater than the recommended {recommended_max_stream_pool_size} for {cpus} logical CPUs, using recommended value.",
+            style="yellow",
         )
         final_max_stream_pool_size = str(recommended_max_stream_pool_size)
 
-    # Prompt user for connection refresh interval with a default of 60 seconds
-    # Use existing value as default if updating, otherwise use 60
-    default_connection_refresh_interval = existing_env_vars.get(
-        "CONNECTION_REFRESH_INTERVAL_SEC", "60"
-    )
-    final_connection_refresh_interval = connection_refresh_interval or Prompt.ask(
-        "👉 Enter connection refresh interval for local collector to sequencer (seconds)",
-        default=default_connection_refresh_interval,
+    # Don't prompt for connection refresh interval - use existing or 60 seconds
+    final_connection_refresh_interval = (
+        connection_refresh_interval
+        or existing_env_vars.get("CONNECTION_REFRESH_INTERVAL_SEC")
+        or "60"
     )
     env_contents = []
     if final_wallet_address:

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -278,9 +278,13 @@ def configure_command(
     )
 
     # Prompt user for max stream pool size
+    # Use existing value as default if updating, otherwise use recommended value
+    default_max_stream_pool_size = existing_env_vars.get(
+        "MAX_STREAM_POOL_SIZE", str(recommended_max_stream_pool_size)
+    )
     final_max_stream_pool_size = max_stream_pool_size or Prompt.ask(
         "👉 Enter max stream pool size for local collector",
-        default=str(recommended_max_stream_pool_size),
+        default=default_max_stream_pool_size,
     )
     if int(final_max_stream_pool_size) > recommended_max_stream_pool_size:
         console.print(
@@ -289,10 +293,14 @@ def configure_command(
         )
         final_max_stream_pool_size = str(recommended_max_stream_pool_size)
 
-    # Prompt user for connection refresh interval with a default of 120 seconds
+    # Prompt user for connection refresh interval with a default of 60 seconds
+    # Use existing value as default if updating, otherwise use 60
+    default_connection_refresh_interval = existing_env_vars.get(
+        "CONNECTION_REFRESH_INTERVAL_SEC", "60"
+    )
     final_connection_refresh_interval = connection_refresh_interval or Prompt.ask(
-        "👉 Enter connection refresh interval for local collector to sequencer",
-        default="75",
+        "👉 Enter connection refresh interval for local collector to sequencer (seconds)",
+        default=default_connection_refresh_interval,
     )
     env_contents = []
     if final_wallet_address:

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -279,6 +279,17 @@ def configure_command(
         or "https://tg-testing.powerloom.io/"
     )
 
+    # Prompt for Telegram notification cooldown only if chat ID is provided
+    final_telegram_cooldown = ""
+    if final_telegram_chat:
+        default_cooldown = existing_env_vars.get(
+            "TELEGRAM_NOTIFICATION_COOLDOWN", "300"
+        )
+        final_telegram_cooldown = Prompt.ask(
+            "👉 Enter Telegram notification cooldown in seconds (optional)",
+            default=default_cooldown,
+        )
+
     # Don't prompt for max stream pool size - use existing or recommended value
     final_max_stream_pool_size = (
         max_stream_pool_size
@@ -313,6 +324,8 @@ def configure_command(
         env_contents.append(f"TELEGRAM_CHAT_ID={final_telegram_chat}")
     if final_telegram_url:
         env_contents.append(f"TELEGRAM_REPORTING_URL={final_telegram_url}")
+    if final_telegram_cooldown:
+        env_contents.append(f"TELEGRAM_NOTIFICATION_COOLDOWN={final_telegram_cooldown}")
     if final_max_stream_pool_size:
         env_contents.append(f"MAX_STREAM_POOL_SIZE={final_max_stream_pool_size}")
     if final_connection_refresh_interval:

--- a/snapshotter_cli/utils/changelog.py
+++ b/snapshotter_cli/utils/changelog.py
@@ -59,6 +59,8 @@ def format_changelog_content(content: str) -> str:
     Returns:
         Formatted content string for Rich console display
     """
+    import re
+
     formatted_lines = []
     lines = content.split("\n")
 
@@ -95,16 +97,27 @@ def format_changelog_content(content: str) -> str:
             else:
                 formatted_lines.append(line)
         elif line.startswith("- "):
-            # Bullet points
-            formatted_lines.append(f"  • {line[2:]}")
+            # Bullet points - handle inline bold text
+            bullet_content = line[2:]
+            # Replace **text** with [bold]text[/bold]
+            bullet_content = re.sub(
+                r"\*\*([^*]+)\*\*", r"[bold]\1[/bold]", bullet_content
+            )
+            formatted_lines.append(f"  • {bullet_content}")
         elif line.startswith("  - "):
-            # Sub-bullet points
-            formatted_lines.append(f"    ◦ {line[4:]}")
+            # Sub-bullet points - handle inline bold text
+            sub_bullet_content = line[4:]
+            sub_bullet_content = re.sub(
+                r"\*\*([^*]+)\*\*", r"[bold]\1[/bold]", sub_bullet_content
+            )
+            formatted_lines.append(f"    ◦ {sub_bullet_content}")
         elif line.startswith("**") and line.endswith("**") and len(line) > 4:
-            # Bold text
+            # Bold text (entire line)
             formatted_lines.append(f"[bold]{line[2:-2]}[/bold]")
         elif line.strip():
-            formatted_lines.append(line)
+            # Regular lines - also handle inline bold text
+            formatted_line = re.sub(r"\*\*([^*]+)\*\*", r"[bold]\1[/bold]", line)
+            formatted_lines.append(formatted_line)
         else:
             formatted_lines.append("")
 
@@ -178,6 +191,8 @@ def get_latest_changes() -> Optional[str]:
     Returns:
         Formatted string of latest changes for shell startup display, or None if not found.
     """
+    import re
+
     try:
         changelog_path = find_changelog_path()
 
@@ -243,8 +258,12 @@ def get_latest_changes() -> Optional[str]:
                     formatted_line += "[/bold yellow]"
                     changes.append(formatted_line)
                 elif line.startswith("- "):
-                    # Format bullet points
-                    changes.append(f"  • {line[2:]}")
+                    # Format bullet points and handle inline bold text
+                    bullet_content = line[2:]
+                    bullet_content = re.sub(
+                        r"\*\*([^*]+)\*\*", r"[bold]\1[/bold]", bullet_content
+                    )
+                    changes.append(f"  • {bullet_content}")
                 elif line.strip() and not line.startswith("#"):
                     changes.append(line)
             elif in_latest_release and line.strip():
@@ -254,8 +273,12 @@ def get_latest_changes() -> Optional[str]:
                     formatted_line += "[/bold yellow]"
                     changes.append(formatted_line)
                 elif line.startswith("- "):
-                    # Format bullet points
-                    changes.append(f"  • {line[2:]}")
+                    # Format bullet points and handle inline bold text
+                    bullet_content = line[2:]
+                    bullet_content = re.sub(
+                        r"\*\*([^*]+)\*\*", r"[bold]\1[/bold]", bullet_content
+                    )
+                    changes.append(f"  • {bullet_content}")
                 elif line.strip() and not line.startswith("#"):
                     changes.append(line)
 

--- a/snapshotter_cli/utils/changelog.py
+++ b/snapshotter_cli/utils/changelog.py
@@ -1,8 +1,13 @@
 """Changelog utilities for displaying and formatting CHANGELOG.md content."""
 
+import importlib.resources as resources
+import os
+import re
 import sys
 from pathlib import Path
 from typing import Optional
+
+from rich.console import Console
 
 from snapshotter_cli.utils.console import console
 
@@ -23,8 +28,6 @@ def find_changelog_path() -> Optional[Path]:
     else:
         # Check pip package installation location
         try:
-            import importlib.resources as resources
-
             # For Python 3.9+
             if hasattr(resources, "files"):
                 package_files = resources.files("snapshotter_cli")
@@ -59,8 +62,6 @@ def format_changelog_content(content: str) -> str:
     Returns:
         Formatted content string for Rich console display
     """
-    import re
-
     formatted_lines = []
     lines = content.split("\n")
 
@@ -130,10 +131,6 @@ def display_changelog():
     This function finds the CHANGELOG.md file, formats it, and displays it
     using Rich's pager for scrollable content.
     """
-    import os
-
-    from rich.console import Console
-
     try:
         # Check if we're in a PyInstaller bundle
         is_frozen = getattr(sys, "frozen", False)
@@ -191,8 +188,6 @@ def get_latest_changes() -> Optional[str]:
     Returns:
         Formatted string of latest changes for shell startup display, or None if not found.
     """
-    import re
-
     try:
         changelog_path = find_changelog_path()
 

--- a/snapshotter_cli/utils/config_helpers.py
+++ b/snapshotter_cli/utils/config_helpers.py
@@ -2,6 +2,8 @@ import os
 from pathlib import Path
 from typing import Dict, Optional
 
+from dotenv import dotenv_values
+
 from snapshotter_cli.utils.console import console
 
 
@@ -31,8 +33,6 @@ def get_credential(
         cwd_dot_env_path = Path(os.getcwd()) / ".env"
         if cwd_dot_env_path.exists():
             try:
-                from dotenv import dotenv_values
-
                 cwd_env_vars = dotenv_values(cwd_dot_env_path)
                 if env_var_name in cwd_env_vars:
                     return cwd_env_vars[env_var_name]
@@ -67,8 +67,6 @@ def get_source_chain_rpc_url(
         cwd_dot_env_path = Path(os.getcwd()) / ".env"
         if cwd_dot_env_path.exists():
             try:
-                from dotenv import dotenv_values
-
                 cwd_env_vars = dotenv_values(cwd_dot_env_path)
                 # Try chain-specific var first
                 if source_chain_specific_env_var in cwd_env_vars:

--- a/snapshotter_cli/utils/console.py
+++ b/snapshotter_cli/utils/console.py
@@ -3,6 +3,8 @@ Console utilities for consistent terminal handling across the CLI.
 Fixes newline issues in PyInstaller Linux builds.
 """
 
+import getpass
+import re
 import sys
 from typing import Optional
 
@@ -51,8 +53,6 @@ class Prompt(RichPrompt):
         # For PyInstaller builds on Linux, use a simpler approach
         if getattr(sys, "frozen", False) and sys.platform.startswith("linux"):
             # Strip Rich markup tags for plain text display
-            import re
-
             plain_prompt = re.sub(r"\[.*?\]", "", prompt)
 
             # Print prompt with default value on the same line
@@ -62,8 +62,6 @@ class Prompt(RichPrompt):
 
             # Use standard input() to avoid Rich's terminal handling issues
             if password:
-                import getpass
-
                 print(prompt_text, end="", flush=True)
                 value = getpass.getpass(" ")
             else:

--- a/snapshotter_cli/utils/evm.py
+++ b/snapshotter_cli/utils/evm.py
@@ -3,13 +3,13 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
+from web3 import Web3
+
 from snapshotter_cli.utils.console import console
 
 # Handle PyInstaller bundled files
 if getattr(sys, "frozen", False):
     # Running in a PyInstaller bundle
-    import sys
-
     base_path = Path(sys._MEIPASS)
     ABI_DIR = base_path / "snapshotter_cli" / "utils" / "abi"
     # Also check if files are in the root of _MEIPASS
@@ -46,8 +46,6 @@ def fetch_owned_slots(
         return None
 
     try:
-        from web3 import Web3
-
         w3 = Web3(Web3.HTTPProvider(rpc_url))
         if not w3.is_connected():
             console.print(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,76 @@
 """Basic tests for Powerloom Snapshotter CLI"""
 
-from snapshotter_cli import __version__
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from snapshotter_cli import __version__, get_version_string
+from snapshotter_cli.cli import app
+from snapshotter_cli.utils.models import ChainConfig, PowerloomChainConfig
 
 
 def test_version():
-    """Test that version is defined."""
-    assert __version__ == "0.1.0"
+    """Test that version is defined and follows expected format."""
+    # Just check that version exists and is a string
+    assert isinstance(__version__, str)
+    assert len(__version__) > 0
+    # Check it follows semantic versioning pattern
+    parts = __version__.split(".")
+    assert len(parts) >= 2  # At least major.minor
+
+
+def test_get_version_string():
+    """Test that get_version_string returns a properly formatted version."""
+    version_str = get_version_string()
+    assert isinstance(version_str, str)
+    assert __version__ in version_str  # Should contain base version
+
+
+def test_cli_help():
+    """Test that CLI help command works."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "Powerloom Snapshotter Node Management CLI" in result.stdout
+
+
+def test_cli_version():
+    """Test that CLI version command works."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert "Powerloom Snapshotter CLI version:" in result.stdout
+
+
+def test_list_command():
+    """Test that list command works."""
+    runner = CliRunner()
+    # Mock the fetch_markets_config to avoid network calls
+    with patch("snapshotter_cli.cli.fetch_markets_config") as mock_fetch:
+        mock_fetch.return_value = []
+        result = runner.invoke(app, ["list"])
+        # Should fail gracefully when no markets config
+        assert result.exit_code == 1
+
+
+def test_status_command():
+    """Test that status command works."""
+    runner = CliRunner()
+    # Mock the screen sessions check
+    with patch("snapshotter_cli.cli.list_snapshotter_screen_sessions") as mock_list:
+        mock_list.return_value = []
+        with patch("snapshotter_cli.cli.fetch_markets_config") as mock_fetch:
+            # Create a proper PowerloomChainConfig object
+            chain_config = ChainConfig(name="TEST", chainId=1, rpcURL="http://test")
+            powerloom_config = PowerloomChainConfig(
+                powerloomChain=chain_config, dataMarkets=[]
+            )
+            mock_fetch.return_value = [powerloom_config]
+
+            result = runner.invoke(app, ["status"])
+            assert result.exit_code == 0
+            assert "No running screen sessions found" in result.stdout


### PR DESCRIPTION
Fixes #76

### Overview
This PR simplifies the configuration process by removing unnecessary prompts for technical parameters that rarely need customization. The configure command now automatically sets optimal values for `MAX_STREAM_POOL_SIZE`, `CONNECTION_REFRESH_INTERVAL_SEC`, and `TELEGRAM_REPORTING_URL` while preserving any existing custom values.

### Problem Solved
1. Users were unnecessarily prompted for technical values they typically don't understand or need to change
2. When updating configurations, existing values weren't being preserved for some fields
3. Configuration process was longer than needed with too many prompts

### Solution
Removed prompts for technical parameters and implemented smart defaults that:
- Preserve existing values when updating configurations
- Use optimal defaults for new configurations
- Reduce configuration time and complexity

### Changes Made

#### Removed Prompts for Technical Parameters

**TELEGRAM_REPORTING_URL**:
- No longer prompts user
- Uses existing value if updating configuration
- Defaults to `https://tg-testing.powerloom.io/` for new configurations

**MAX_STREAM_POOL_SIZE**:
- No longer prompts user
- Uses existing value if updating configuration
- Defaults to CPU-optimized value (20 for <2 CPUs, 40 for 2-4 CPUs, 100 for 4+ CPUs)
- Automatically caps at recommended value if exceeded

**CONNECTION_REFRESH_INTERVAL_SEC**:
- No longer prompts user
- Uses existing value if updating configuration
- Defaults to 60 seconds (improved from previous 75 seconds)

#### Added Conditional Prompt

**TELEGRAM_NOTIFICATION_COOLDOWN**:
- Only prompts when Telegram chat ID is provided
- Uses existing value as default when updating
- Defaults to 300 seconds (5 minutes) for new configurations
- Helps prevent notification spam while keeping it configurable

### User Impact

#### Before
- Configuration required answering 9+ prompts
- Users had to understand technical parameters they rarely need to change
- Risk of accidentally overwriting existing values when updating

#### After
- Configuration reduced to 6-7 prompts (wallet, signer, RPC, telegram chat, plus cooldown if chat ID provided)
- Technical parameters automatically set to optimal values
- Existing values always preserved when updating
- Smart conditional prompting based on user choices
- Faster and simpler configuration experience

### Testing
```bash
# First configuration - only essential prompts shown
powerloom-snapshotter-cli configure --env devnet --market uniswapv2
# Prompts for: wallet, signer address, signer key, RPC URL, telegram chat ID
# If telegram chat ID provided, also prompts for cooldown (default 300)
# Technical parameters set automatically

# Check the generated .env file
cat ~/.powerloom-snapshotter-cli/envs/.env.devnet.uniswapv2.*
# Should see TELEGRAM_REPORTING_URL=https://tg-testing.powerloom.io/
# Should see MAX_STREAM_POOL_SIZE=(CPU-based value)
# Should see CONNECTION_REFRESH_INTERVAL_SEC=60
# If telegram configured: TELEGRAM_NOTIFICATION_COOLDOWN=300 (or custom value)

# Update configuration - existing values preserved
powerloom-snapshotter-cli configure --env devnet --market uniswapv2
# All values including cooldown show existing settings as defaults
```

### Additional Fixes (Latest Commits)

#### Documentation Cleanup (13268b8)
- **Removed non-existent commands**: Cleaned up references to `logs`, `stop`, `restart`, and `cleanup` commands that don't exist in the CLI
- **Updated command examples**: Replaced `logs` command with `status` command in all documentation
- **Accurate command list**: Documentation now only lists the 7 commands that actually exist: `configure`, `deploy`, `diagnose`, `identity`, `list`, `shell`, `status`

#### Bug Fix: Status Command Style Error (77dfb78)
- **Fixed `MissingStyle` error**: Status command was using invalid `style="info"` when filtering with `--env` or `--market` flags
- **Changed to valid style**: Updated to use `style="dim"` for proper Rich terminal rendering

#### Import Organization and Test Fixes (793849c)
- **Fixed circular import**: Resolved circular dependency between `cli.py` and `shell.py` by passing app as parameter
- **Organized imports**: Moved all imports to the top of files following Python best practices
- **Fixed test suite**: Updated tests to properly mock objects and removed outdated version check
- **Enhanced test coverage**: Added comprehensive tests for CLI commands including help, version, list, and status
- **Fixed GitHub workflow**: Removed "No tests found, continuing..." fallback - tests now run properly

### Files Modified
- `snapshotter_cli/commands/configure.py` - Fixed default value handling and organized imports
- `snapshotter_cli/cli.py` - Fixed status command style error and circular import issue
- `snapshotter_cli/commands/shell.py` - Fixed circular import by accepting app as parameter
- `snapshotter_cli/utils/*.py` - Organized imports in all utility files
- `tests/test_cli.py` - Updated tests with proper mocking and removed hardcoded version check
- `.github/workflows/publish-pypi.yml` - Removed test fallback, tests now required to pass
- `README.md` - Removed references to non-existent commands
- `CLI_DOCUMENTATION.md` - Cleaned up command documentation
- `CHANGELOG.md` - Documented all fixes in Unreleased section

### Testing
- All 6 tests now pass successfully
- Tests cover: version format, version string, CLI help, CLI version, list command, status command
- GitHub Actions workflow properly runs tests without fallback
- All CLI commands verified working: `--version`, `--help`, `--changelog`, `list`, `status`, `shell`, `identity`, `diagnose`, `configure`, `deploy`

### Related Issue
Closes #76 