### PR TITLE
fix: CLI not reading LITE_NODE_BRANCH from configuration when cloning snapshotter-lite-v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **LITE_NODE_BRANCH configuration (#79)** - CLI now properly reads and uses LITE_NODE_BRANCH from environment configuration when cloning snapshotter-lite-v2
 - **Configuration value preservation (#76)** - Technical parameters now properly preserve existing values when updating configuration
 
 ### Changed

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -650,6 +650,20 @@ def deploy(
             console.print("🤷 No data markets selected for deployment.", style="yellow")
             raise typer.Exit(0)
 
+        # Get LITE_NODE_BRANCH from namespaced env content or use default
+        lite_node_branch = "main"  # default branch
+        if namespaced_env_content and "LITE_NODE_BRANCH" in namespaced_env_content:
+            lite_node_branch = namespaced_env_content["LITE_NODE_BRANCH"]
+            console.print(
+                f"📌 Using LITE_NODE_BRANCH from configuration: [bold cyan]{lite_node_branch}[/bold cyan]",
+                style="dim",
+            )
+        else:
+            console.print(
+                f"📌 No LITE_NODE_BRANCH found in configuration, using default: [bold cyan]{lite_node_branch}[/bold cyan]",
+                style="dim",
+            )
+
         console.print(
             f"🛠️ Preparing base snapshotter-lite-v2 clone at {base_snapshotter_clone_path}...",
             style="blue",
@@ -682,13 +696,15 @@ def deploy(
         snapshotter_lite_repo_url = (
             "https://github.com/PowerLoom/snapshotter-lite-v2.git"
         )
+        # Clone with the specified branch
+        clone_command = ["git", "clone", "--branch", lite_node_branch, snapshotter_lite_repo_url, "."]
         if not run_git_command(
-            ["git", "clone", snapshotter_lite_repo_url, "."],
+            clone_command,
             cwd=base_snapshotter_clone_path,
-            desc="Cloning base snapshotter-lite-v2 repository from {snapshotter_lite_repo_url}",
+            desc=f"Cloning base snapshotter-lite-v2 repository from {{snapshotter_lite_repo_url}} (branch: {lite_node_branch})",
         ):
             console.print(
-                f"❌ Failed to clone base snapshotter-lite-v2 repository from {snapshotter_lite_repo_url}.",
+                f"❌ Failed to clone base snapshotter-lite-v2 repository from {snapshotter_lite_repo_url} (branch: {lite_node_branch}).",
                 style="bold red",
             )
             # Cleanup already created directory before exiting
@@ -696,7 +712,7 @@ def deploy(
                 shutil.rmtree(base_snapshotter_clone_path)
             raise typer.Exit(1)
         console.print(
-            f"  ✅ Base snapshotter-lite-v2 cloned successfully.", style="green"
+            f"  ✅ Base snapshotter-lite-v2 cloned successfully from branch: [bold cyan]{lite_node_branch}[/bold cyan].", style="green"
         )
 
         successful_deployments = 0

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -697,7 +697,14 @@ def deploy(
             "https://github.com/PowerLoom/snapshotter-lite-v2.git"
         )
         # Clone with the specified branch
-        clone_command = ["git", "clone", "--branch", lite_node_branch, snapshotter_lite_repo_url, "."]
+        clone_command = [
+            "git",
+            "clone",
+            "--branch",
+            lite_node_branch,
+            snapshotter_lite_repo_url,
+            ".",
+        ]
         if not run_git_command(
             clone_command,
             cwd=base_snapshotter_clone_path,
@@ -712,7 +719,8 @@ def deploy(
                 shutil.rmtree(base_snapshotter_clone_path)
             raise typer.Exit(1)
         console.print(
-            f"  ✅ Base snapshotter-lite-v2 cloned successfully from branch: [bold cyan]{lite_node_branch}[/bold cyan].", style="green"
+            f"  ✅ Base snapshotter-lite-v2 cloned successfully from branch: [bold cyan]{lite_node_branch}[/bold cyan].",
+            style="green",
         )
 
         successful_deployments = 0


### PR DESCRIPTION
Fixes #79

## Overview
This PR fixes an issue where the CLI deployment command was not respecting the `LITE_NODE_BRANCH` environment variable from configuration files when cloning the snapshotter-lite-v2 repository.

## Problem Solved
- The CLI was always cloning from the default branch regardless of the `LITE_NODE_BRANCH` setting
- Power users couldn't deploy from alternative branches (e.g., `dockerify`, experimental features)
- The `LITE_NODE_BRANCH` configuration value was being written but never read during deployment

## Solution
The deployment process now:
1. Reads the `LITE_NODE_BRANCH` value from the namespaced environment configuration
2. Uses `git clone --branch <LITE_NODE_BRANCH>` when cloning the repository
3. Provides clear console feedback about which branch is being used
4. Falls back to "main" branch if no configuration is found

## User Impact
**Before:**
- Users set `LITE_NODE_BRANCH=dockerify` in their env file
- CLI ignores this and clones from default branch
- No way to test alternative branches through CLI

**After:**
- Power users can edit their env file to set any branch
- CLI respects the configuration and clones from specified branch
- Clear feedback shows which branch is being used:
  ```
  📌 Using LITE_NODE_BRANCH from configuration: dockerify
  ✅ Base snapshotter-lite-v2 cloned successfully from branch: dockerify
  ```

## Testing
Tested deployment with custom branch:
1. Configure deployment: `snapshotter-cli configure --env DEVNET --market UNISWAPV2`
2. Edit `.env.devnet.uniswapv2.eth_mainnet` and set `LITE_NODE_BRANCH=dockerify`
3. Deploy: `snapshotter-cli deploy --env DEVNET --markets UNISWAPV2 --slots 123`
4. Confirmed CLI clones from `dockerify` branch as expected

## Code Changes
- Modified `snapshotter_cli/cli.py` to read `LITE_NODE_BRANCH` from namespaced env configuration
- Updated git clone command to include `--branch` parameter
- Added console output to show which branch is being used

