### PR TITLE
Add Telegram Message Thread ID Support to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Telegram message thread ID support** - Added `TELEGRAM_MESSAGE_THREAD_ID` configuration option for organizing notifications into specific threads within Telegram chats
+- **Conditional Telegram cooldown prompt** - Only asks for notification cooldown when Telegram chat ID is provided
+
 ### Fixed
 - **LITE_NODE_BRANCH configuration (#79)** - CLI now properly reads and uses LITE_NODE_BRANCH from environment configuration when cloning snapshotter-lite-v2
 - **Configuration value preservation (#76)** - Technical parameters now properly preserve existing values when updating configuration
@@ -16,9 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smart changelog display** - Shows "What's New" only once per version update to reduce notification fatigue
 - **Enhanced markdown formatting** - Bold text in changelog now renders properly in terminal output
 - **Connection refresh interval default** - Changed from 75 to 60 seconds for better performance
-
-### Added
-- **Conditional Telegram cooldown prompt** - Only asks for notification cooldown when Telegram chat ID is provided
 
 ### Improved
 - **Configuration UX** - Reduced from 9+ prompts to 6-7 essential ones, auto-setting technical parameters with smart defaults

--- a/env.example
+++ b/env.example
@@ -9,6 +9,7 @@ WALLET_HOLDER_ADDRESS=<wallet-holder-address>
 POWERLOOM_RPC_URL=https://rpc-v2.powerloom.network
 TELEGRAM_CHAT_ID=<telegram-chat-id>
 TELEGRAM_REPORTING_URL=https://tg-testing.powerloom.io/
+TELEGRAM_MESSAGE_THREAD_ID=
 LITE_NODE_BRANCH=main
 LOCAL_COLLECTOR_IMAGE_TAG=latest
 #CONNECTION_REFRESH_INTERVAL_SEC=60

--- a/multi_clone.py
+++ b/multi_clone.py
@@ -66,6 +66,7 @@ def env_file_template(
     data_market_in_request: str = "false",
     telegram_reporting_url: str = "",
     telegram_chat_id: str = "",
+    telegram_message_thread_id: str = "",
     powerloom_chain: str = POWERLOOM_CHAIN,
     source_chain: str = SOURCE_CHAIN,
     local_collector_port: int = 50051,
@@ -102,6 +103,7 @@ DATA_MARKET_IN_REQUEST={data_market_in_request}
 LOCAL_COLLECTOR_IMAGE_TAG={local_collector_image_tag}
 TELEGRAM_REPORTING_URL={telegram_reporting_url}
 TELEGRAM_CHAT_ID={telegram_chat_id}
+TELEGRAM_MESSAGE_THREAD_ID={telegram_message_thread_id}
 CONNECTION_REFRESH_INTERVAL_SEC={connection_refresh_interval_sec}
 TELEGRAM_NOTIFICATION_COOLDOWN={telegram_notification_cooldown}
 """
@@ -121,6 +123,7 @@ def generate_env_file_contents(data_market_namespace: str, **kwargs) -> str:
         snapshotter_compute_repo=kwargs["snapshotter_compute_repo"],
         snapshotter_compute_repo_branch=kwargs["snapshotter_compute_repo_branch"],
         telegram_chat_id=kwargs["telegram_chat_id"],
+        telegram_message_thread_id=kwargs.get("telegram_message_thread_id", ""),
         telegram_reporting_url=kwargs["telegram_reporting_url"],
         max_stream_pool_size=kwargs["max_stream_pool_size"],
         stream_pool_health_check_interval=kwargs["stream_pool_health_check_interval"],
@@ -247,6 +250,7 @@ def _deploy_single_node_impl(
             snapshotter_config_repo=protocol_state["SNAPSHOTTER_CONFIG_REPO"],
             snapshotter_compute_repo=protocol_state["SNAPSHOTTER_COMPUTE_REPO"],
             telegram_chat_id=kwargs["telegram_chat_id"],
+            telegram_message_thread_id=kwargs.get("telegram_message_thread_id", ""),
             telegram_reporting_url=kwargs["telegram_reporting_url"],
             max_stream_pool_size=kwargs["max_stream_pool_size"],
             stream_pool_health_check_interval=kwargs[
@@ -954,6 +958,7 @@ def main(
         signer_pkey=os.getenv("SIGNER_ACCOUNT_PRIVATE_KEY"),
         powerloom_rpc_url=os.getenv("POWERLOOM_RPC_URL"),
         telegram_chat_id=os.getenv("TELEGRAM_CHAT_ID"),
+        telegram_message_thread_id=os.getenv("TELEGRAM_MESSAGE_THREAD_ID", ""),
         telegram_reporting_url=os.getenv(
             "TELEGRAM_REPORTING_URL", "https://tg-testing.powerloom.io"
         ),

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -68,6 +68,11 @@ def configure_command(
     telegram_reporting_url: Optional[str] = typer.Option(
         "", "--telegram-url", "-u", help="Telegram reporting URL"
     ),
+    telegram_thread_id: Optional[str] = typer.Option(
+        None,
+        "--telegram-thread",
+        help="Telegram message thread ID for organizing notifications",
+    ),
     max_stream_pool_size: Optional[int] = typer.Option(
         None,
         "--max-stream-pool-size",
@@ -278,8 +283,9 @@ def configure_command(
         or "https://tg-testing.powerloom.io/"
     )
 
-    # Prompt for Telegram notification cooldown only if chat ID is provided
+    # Prompt for Telegram notification cooldown and thread ID only if chat ID is provided
     final_telegram_cooldown = ""
+    final_telegram_thread = ""
     if final_telegram_chat:
         default_cooldown = existing_env_vars.get(
             "TELEGRAM_NOTIFICATION_COOLDOWN", "300"
@@ -287,6 +293,12 @@ def configure_command(
         final_telegram_cooldown = Prompt.ask(
             "👉 Enter Telegram notification cooldown in seconds (optional)",
             default=default_cooldown,
+        )
+
+        # Prompt for Telegram thread ID
+        final_telegram_thread = telegram_thread_id or Prompt.ask(
+            "👉 Enter Telegram message thread ID for organizing notifications (optional, leave empty for main chat)",
+            default=existing_env_vars.get("TELEGRAM_MESSAGE_THREAD_ID", ""),
         )
 
     # Don't prompt for max stream pool size - use existing or recommended value
@@ -325,6 +337,8 @@ def configure_command(
         env_contents.append(f"TELEGRAM_REPORTING_URL={final_telegram_url}")
     if final_telegram_cooldown:
         env_contents.append(f"TELEGRAM_NOTIFICATION_COOLDOWN={final_telegram_cooldown}")
+    if final_telegram_thread:
+        env_contents.append(f"TELEGRAM_MESSAGE_THREAD_ID={final_telegram_thread}")
     if final_max_stream_pool_size:
         env_contents.append(f"MAX_STREAM_POOL_SIZE={final_max_stream_pool_size}")
     if final_connection_refresh_interval:


### PR DESCRIPTION
## Overview
This PR adds support for Telegram message threading to the Powerloom Snapshotter CLI, aligning with the feature introduced in [powerloom/snapshotter-lite-v2#144](https://github.com/powerloom/snapshotter-lite-v2/pull/144). This enhancement allows users to organize Telegram notifications into specific threads within a chat, improving message organization and reducing clutter.

## Changes

### Added
- **Telegram Thread ID Configuration**: New `--telegram-thread` option in the `configure` command for specifying message thread IDs
- **Interactive Thread ID Prompt**: When configuring Telegram notifications, users are now prompted for an optional thread ID
- **Environment Variable Support**: Added `TELEGRAM_MESSAGE_THREAD_ID` to environment configuration and templates
- **Multi-Clone Script Support**: Extended `multi_clone.py` to handle thread ID in deployment configurations

### Modified Files
1. **`snapshotter_cli/commands/configure.py`**
   - Added `telegram_thread_id` parameter to configure command
   - Added interactive prompt for thread ID when Telegram chat ID is provided
   - Thread ID is saved to namespaced .env files

2. **`multi_clone.py`**
   - Added `telegram_message_thread_id` parameter to `env_file_template()` function
   - Updated environment file generation to include `TELEGRAM_MESSAGE_THREAD_ID`
   - Added support for reading thread ID from environment variables

3. **`env.example`**
   - Added `TELEGRAM_MESSAGE_THREAD_ID=` as a documented environment variable

## Usage

### CLI Configuration
```bash
# Configure with thread ID via command line
powerloom-snapshotter-cli configure --telegram-chat "123456789" --telegram-thread "42"

# Or configure interactively
powerloom-snapshotter-cli configure
# When prompted for Telegram settings:
# 👉 Enter Telegram chat ID: 123456789
# 👉 Enter Telegram message thread ID (optional, leave empty for main chat): 42
```

### Environment Variable
```bash
# In .env file
TELEGRAM_CHAT_ID=123456789
TELEGRAM_MESSAGE_THREAD_ID=42  # Optional - leave empty for main chat
```

## Benefits
- **Better Organization**: Notifications can be grouped into specific threads/topics
- **Reduced Clutter**: Main chat remains clean with messages organized in threads
- **Backward Compatible**: Thread ID is optional - existing configurations work without changes
- **Consistent Experience**: Works seamlessly with both CLI and traditional deployment methods

## Testing
- ✅ CLI configure command accepts `--telegram-thread` parameter
- ✅ Interactive prompts include thread ID when Telegram chat is configured
- ✅ Thread ID is properly saved to environment files
- ✅ Multi-clone script supports thread ID in generated configurations
- ✅ Code passes linting and formatting checks

## Related Issues
- Implements feature from [powerloom/snapshotter-lite-v2#144](https://github.com/powerloom/snapshotter-lite-v2/pull/144)
- Fixes [powerloom/snapshotter-lite-v2#143](https://github.com/powerloom/snapshotter-lite-v2/issues/143)