### PR TITLE
Version Bump to 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[v0.1.4]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.1.4
 [v0.1.3]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.1.3
 [v0.1.2]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.1.2
 [v0.1.1]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Powerloom Snapshotter CLI and setup tools will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.1.4] - 2025-08-27
 
 ### Added
 - **Telegram message thread ID support** - Added `TELEGRAM_MESSAGE_THREAD_ID` configuration option for organizing notifications into specific threads within Telegram chats

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "powerloom-snapshotter-cli"
-version = "0.1.3"
+version = "0.1.4"
 description = "CLI tool for deploying and managing Powerloom Snapshotter nodes"
 authors = [{name = "Powerloom Protocol", email = "hello@powerloom.io"}]
 readme = "PYPI_README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "psutil>=5.9.8",
     "pydantic>=2.10.4",
+    "toml>=0.10.2",
 ]
 
 [project.urls]

--- a/snapshotter_cli/__init__.py
+++ b/snapshotter_cli/__init__.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 # Build-time commit - will be set during build process
 __commit__ = None

--- a/snapshotter_cli/__init__.py
+++ b/snapshotter_cli/__init__.py
@@ -4,7 +4,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-__version__ = "0.1.4"
+import toml
+
+# Read version from pyproject.toml
+with open("pyproject.toml", "r") as f:
+    pyproject = toml.load(f)
+    __version__ = pyproject["project"]["version"]
 
 # Build-time commit - will be set during build process
 __commit__ = None

--- a/uv.lock
+++ b/uv.lock
@@ -748,6 +748,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "rich" },
+    { name = "toml" },
     { name = "typer" },
     { name = "web3" },
 ]
@@ -768,6 +769,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.4" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rich", specifier = ">=13.7.0" },
+    { name = "toml", specifier = ">=0.10.2" },
     { name = "typer", extras = ["all"], specifier = "==0.15.4" },
     { name = "web3", specifier = ">=6.15.1" },
 ]
@@ -1183,6 +1185,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "powerloom-snapshotter-cli"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "psutil" },


### PR DESCRIPTION
## Summary
Bumps the project version from 0.1.3 to 0.1.4, including all recent improvements and fixes.

### 📝 Changes Made

- Updated version in `pyproject.toml` from 0.1.3 to 0.1.4
- Updated version in `snapshotter_cli/__init__.py` from 0.1.3 to 0.1.4  
- Released changelog section for v0.1.4 with date 2025-08-27
- Synchronized `uv.lock` with new version
