### PR TITLE
🐛 Fix PyInstaller Binary Runtime Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Powerloom Snapshotter CLI and setup tools will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **PyInstaller binary runtime error** - Fixed FileNotFoundError when running binary by including `pyproject.toml` in the PyInstaller bundle
+
 ## [v0.1.4] - 2025-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to the Powerloom Snapshotter CLI and setup tools will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.1.5] - 2025-08-31
 
 ### Fixed
-- **PyInstaller binary runtime error** - Fixed FileNotFoundError when running binary by including `pyproject.toml` in the PyInstaller bundle
+- **PyInstaller binary runtime error** - Fixed FileNotFoundError when running binary by including `pyproject.toml` in the PyInstaller bundle and handling the bundled file path correctly
 
 ## [v0.1.4] - 2025-08-27
 
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[v0.1.5]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.1.5
 [v0.1.4]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.1.4
 [v0.1.3]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.1.3
 [v0.1.2]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.1.2

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -25,6 +25,7 @@ a = Analysis(
     datas=[
         (str(current_dir / 'snapshotter_cli/utils/abi/PowerloomNodes.json'), 'snapshotter_cli/utils/abi'),
         (str(current_dir / 'snapshotter_cli/utils/abi/ProtocolState.json'), 'snapshotter_cli/utils/abi'),
+        (str(current_dir / 'pyproject.toml'), '.'),  # Include pyproject.toml in the root of the bundle
         (str(current_dir / 'CHANGELOG.md'), '.'),  # Include CHANGELOG.md in the root of the bundle
     ] + py_ecc_datas,
     hiddenimports=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "powerloom-snapshotter-cli"
-version = "0.1.4"
+version = "0.1.5"
 description = "CLI tool for deploying and managing Powerloom Snapshotter nodes"
 authors = [{name = "Powerloom Protocol", email = "hello@powerloom.io"}]
 readme = "PYPI_README.md"

--- a/snapshotter_cli/__init__.py
+++ b/snapshotter_cli/__init__.py
@@ -7,7 +7,17 @@ from pathlib import Path
 import toml
 
 # Read version from pyproject.toml
-with open("pyproject.toml", "r") as f:
+# Handle PyInstaller bundle case
+if getattr(sys, "frozen", False):
+    # We're running in a PyInstaller bundle
+    # pyproject.toml is bundled in the root of _MEIPASS
+    base_path = Path(sys._MEIPASS)
+    pyproject_path = base_path / "pyproject.toml"
+else:
+    # Normal development mode
+    pyproject_path = Path("pyproject.toml")
+
+with open(pyproject_path, "r") as f:
     pyproject = toml.load(f)
     __version__ = pyproject["project"]["version"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "powerloom-snapshotter-cli"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "psutil" },


### PR DESCRIPTION
### Problem
The PyInstaller-built binary was failing at runtime with:
```
FileNotFoundError: [Errno 2] No such file or directory: 'pyproject.toml'
```

This occurred because `snapshotter_cli/__init__.py` was trying to read `pyproject.toml` to get the version, but the file wasn't included in the binary bundle and the code didn't handle the PyInstaller bundle path correctly.

### Solution
1. **Added `pyproject.toml` to PyInstaller bundle** - Updated `pyinstaller.spec` to include `pyproject.toml` in the binary distribution
2. **Fixed path handling for bundled execution** - Modified `snapshotter_cli/__init__.py` to detect PyInstaller runtime and look for `pyproject.toml` in the correct `sys._MEIPASS` directory

### Changes
- `pyinstaller.spec`: Added `pyproject.toml` to the `datas` list for bundling
- `snapshotter_cli/__init__.py`: Added PyInstaller bundle detection and proper path resolution
- `pyproject.toml`: Bumped version to 0.1.5
- `CHANGELOG.md`: Documented the fix in v0.1.5 release notes

### Testing
✅ Built binary with `PLATFORM=linux ARCH=amd64 uv run pyinstaller pyinstaller.spec`
✅ Verified binary runs without errors: `./dist/powerloom-snapshotter-cli-linux-amd64 shell`
✅ Confirmed version displays correctly as v0.1.5

### Impact
This fix ensures that distributed PyInstaller binaries work correctly out of the box, improving the user experience for those downloading pre-built binaries from releases.