### PR TITLE
Fix: Configure command overwrite prompt now properly handles invalid input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Powerloom Snapshotter CLI and setup tools will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Configure overwrite prompt (#88)** - Fixed issue where pressing any key other than 'y' or 'n' would abort configuration. Now re-prompts for valid input instead of aborting
+
 ## [v0.1.5] - 2025-08-31
 
 ### Fixed

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -353,12 +353,25 @@ def configure_command(
     env_contents.append("LOCAL_COLLECTOR_IMAGE_TAG=latest")
 
     if env_file_path.exists():
-        overwrite = typer.confirm(
-            f"⚠️ {env_filename} already exists. Overwrite?", default=False
-        )
-        if not overwrite:
-            console.print("❌ Aborted.", style="yellow")
-            raise typer.Exit(1)
+        while True:
+            response = (
+                Prompt.ask(
+                    f"⚠️ {env_filename} already exists. Overwrite? [y/N]", default="n"
+                )
+                .lower()
+                .strip()
+            )
+
+            if response in ["y", "yes"]:
+                break  # Proceed with overwrite
+            elif response in ["n", "no", ""]:
+                console.print("❌ Aborted.", style="yellow")
+                raise typer.Exit(1)
+            else:
+                console.print(
+                    "❌ Invalid input. Please enter 'y' for yes or 'n' for no.",
+                    style="red",
+                )
 
     try:
         with open(env_file_path, "w") as f:


### PR DESCRIPTION
**Issue:** #88  
**Type:** Bug fix

### Problem
Previously, when the `configure` command encountered an existing configuration file, the overwrite prompt would immediately abort if any key other than 'y' or 'n' was pressed. This was frustrating for users who accidentally pressed the wrong key.

### Solution
Replaced `typer.confirm()` with a custom confirmation loop using `Prompt.ask()` that:
- Re-prompts when invalid input is entered (anything other than y/yes/n/no)
- Shows a clear error message: "Invalid input. Please enter 'y' for yes or 'n' for no."
- Only aborts when user explicitly chooses 'n', 'no', or presses Enter (defaults to 'n')
- Continues with overwrite when user enters 'y' or 'yes'

### Testing
Tested with various inputs:
- Valid inputs: 'y', 'yes', 'n', 'no', Enter key (defaults to 'n')
- Invalid inputs: 'x', 'q', random characters - all now show error and re-prompt

### Changes
- `snapshotter_cli/commands/configure.py`: Replaced typer.confirm with custom loop
- `CHANGELOG.md`: Added entry under Unreleased section