### PR TITLE
Fix: Pass OVERRIDE_DEFAULTS environment variable to lite v2 deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Configure overwrite prompt (#88)** - Fixed issue where pressing any key other than 'y' or 'n' would abort configuration. Now re-prompts for valid input instead of aborting
+- **OVERRIDE_DEFAULTS environment variable** - Fixed multi_clone.py not passing OVERRIDE_DEFAULTS from .env to lite v2 deployments
 
 ## [v0.1.5] - 2025-08-31
 

--- a/multi_clone.py
+++ b/multi_clone.py
@@ -75,6 +75,7 @@ def env_file_template(
     local_collector_image_tag: str = "latest",
     telegram_notification_cooldown: int = 300,
     connection_refresh_interval_sec: int = 60,
+    override_defaults: str = "false",
 ) -> str:
     full_namespace = f"{powerloom_chain}-{namespace}-{source_chain}"
     docker_network_name = f"snapshotter-lite-v2-{full_namespace}"
@@ -106,6 +107,7 @@ TELEGRAM_CHAT_ID={telegram_chat_id}
 TELEGRAM_MESSAGE_THREAD_ID={telegram_message_thread_id}
 CONNECTION_REFRESH_INTERVAL_SEC={connection_refresh_interval_sec}
 TELEGRAM_NOTIFICATION_COOLDOWN={telegram_notification_cooldown}
+OVERRIDE_DEFAULTS={override_defaults}
 """
 
 
@@ -129,6 +131,7 @@ def generate_env_file_contents(data_market_namespace: str, **kwargs) -> str:
         stream_pool_health_check_interval=kwargs["stream_pool_health_check_interval"],
         local_collector_image_tag=kwargs["local_collector_image_tag"],
         connection_refresh_interval_sec=kwargs["connection_refresh_interval_sec"],
+        override_defaults=kwargs.get("override_defaults", "false"),
     )
 
 
@@ -259,6 +262,7 @@ def _deploy_single_node_impl(
             local_collector_image_tag=kwargs["local_collector_image_tag"],
             slot_id=slot_id,
             connection_refresh_interval_sec=kwargs["connection_refresh_interval_sec"],
+            override_defaults=kwargs.get("override_defaults", "false"),
         )
 
         env_file_path = os.path.join(repo_path, f".env-{full_namespace}")
@@ -1076,6 +1080,7 @@ def main(
         ),
         local_collector_image_tag=local_collector_image_tag,
         connection_refresh_interval_sec=connection_refresh_interval,
+        override_defaults=os.getenv("OVERRIDE_DEFAULTS", "false"),
         parallel_workers=parallel_workers,
         sequential=sequential,
     )


### PR DESCRIPTION
## Problem
The `OVERRIDE_DEFAULTS` environment variable was not being passed from the main `.env` file to the lite v2 deployments when using `multi_clone.py`. This prevented users from overriding default configurations in their deployed nodes.

## Solution
Modified `multi_clone.py` to read `OVERRIDE_DEFAULTS` from the environment and include it in the generated `.env` files for each lite v2 deployment.

## Changes Made

### `multi_clone.py`
- Added `override_defaults` parameter to the `env_file_template` function with a default value of `"false"`
- Updated `generate_env_file_contents` to read and pass `OVERRIDE_DEFAULTS` from kwargs
- Modified `_deploy_single_node_impl` to include `override_defaults` when generating env file contents
- Updated `main` function to read `OVERRIDE_DEFAULTS` from the environment and pass it to `run_snapshotter_lite_v2`
- Added `OVERRIDE_DEFAULTS={override_defaults}` to the generated `.env` template

### `CHANGELOG.md`
- Added entry under "Unreleased" section documenting the fix

## Impact
Users can now set `OVERRIDE_DEFAULTS=true` in their main `.env` file and it will be properly propagated to all lite v2 node deployments, allowing them to override default configurations as intended.

## Testing
The change ensures that:
- When `OVERRIDE_DEFAULTS` is set in `.env`, it gets included in generated env files for each node
- When not set, it defaults to `"false"` maintaining backward compatibility
- The CLI (`snapshotter_cli`) already sets this to `"true"` by default, maintaining consistency

## Files Changed
- `multi_clone.py` - 5 modifications to support OVERRIDE_DEFAULTS pass-through
- `CHANGELOG.md` - Added fix entry

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)