### PR TITLE
Add Selective Cleanup Filters to Diagnose Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Selective cleanup filters (#89)** - Added `--slot-id`, `--chain`, and `--market` filter options to `diagnose` command for targeted cleanup of specific deployments instead of cleaning everything at once
+
 ### Fixed
 - **Configure overwrite prompt (#88)** - Fixed issue where pressing any key other than 'y' or 'n' would abort configuration. Now re-prompts for valid input instead of aborting
 - **OVERRIDE_DEFAULTS environment variable** - Fixed multi_clone.py not passing OVERRIDE_DEFAULTS from .env to lite v2 deployments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Selective cleanup filters (#89)** - Added `--slot-id`, `--chain`, and `--market` filter options to `diagnose` command for targeted cleanup of specific deployments instead of cleaning everything at once
+- **Selective cleanup filters (#89)** - Added `--slot-id`, `--chain`, and `--market` filter options to `diagnose` command (CLI, shell mode, and legacy `diagnose.sh` script) for targeted cleanup of specific deployments instead of cleaning everything at once
 
 ### Fixed
 - **Configure overwrite prompt (#88)** - Fixed issue where pressing any key other than 'y' or 'n' would abort configuration. Now re-prompts for valid input instead of aborting

--- a/CLI_DOCUMENTATION.md
+++ b/CLI_DOCUMENTATION.md
@@ -185,8 +185,11 @@ powerloom-snapshotter> list
 powerloom-snapshotter> status --env devnet --market uniswapv2
 [Shows status of instances...]
 
-powerloom-snapshotter> diagnose --clean
-[Runs diagnostics and cleanup...]
+powerloom-snapshotter> diagnose --clean --slot-id 5483
+[Runs diagnostics and cleans up only slot 5483...]
+
+powerloom-snapshotter> diagnose --clean --chain mainnet --market uniswapv2
+[Runs diagnostics and cleans up only mainnet UNISWAPV2 deployments...]
 
 powerloom-snapshotter> exit
 Goodbye!
@@ -309,7 +312,7 @@ powerloom-snapshotter-cli status --env devnet --market uniswapv2
 
 ### diagnose
 
-Run diagnostics on the system and optionally clean up existing deployments.
+Run diagnostics on the system and optionally clean up existing deployments. Supports filtering to target specific slot IDs, chains, or markets for selective cleanup.
 
 ```bash
 powerloom-snapshotter-cli diagnose [OPTIONS]
@@ -318,14 +321,38 @@ powerloom-snapshotter-cli diagnose [OPTIONS]
 **Options:**
 - `--clean, -c`: Clean up existing deployments
 - `--force, -f`: Force cleanup without confirmation (use with --clean)
+- `--slot-id, -s TEXT`: Filter by specific slot ID
+- `--chain TEXT`: Filter by chain name (e.g., 'mainnet', 'devnet')
+- `--market, -m TEXT`: Filter by data market name (e.g., 'uniswapv2', 'aavev3')
+
+**Examples:**
+
+```bash
+# Clean up all containers and screen sessions across all chains/markets
+powerloom-snapshotter-cli diagnose --clean --force
+
+# Clean up only containers/sessions for a specific slot ID
+powerloom-snapshotter-cli diagnose --clean --slot-id 5483
+
+# Clean up only mainnet deployments
+powerloom-snapshotter-cli diagnose --clean --chain mainnet
+
+# Clean up only UNISWAPV2 market deployments
+powerloom-snapshotter-cli diagnose --clean --market uniswapv2
+
+# Clean up specific combination (mainnet + UNISWAPV2)
+powerloom-snapshotter-cli diagnose --clean --chain mainnet --market uniswapv2
+
+# Clean up specific slot on devnet AAVEV3 market
+powerloom-snapshotter-cli diagnose --clean --slot-id 1234 --chain devnet --market aavev3
+```
 
 **Diagnostics include:**
-- Python version check
-- System resources (CPU, memory, disk)
 - Docker installation and status
-- Network connectivity
-- Required port availability
-- Running instances status
+- Docker Compose availability
+- Running Powerloom containers (filtered by provided options)
+- Docker networks
+- Screen sessions (filtered by provided options)
 
 ### identity
 

--- a/README.md
+++ b/README.md
@@ -477,6 +477,24 @@ The multi setup comes bundled with a diagnostic and cleanup script.
 > [!NOTE]
 > The `-y` flag is recommended to be used as it will skip all the prompts and cleanup existing Powerloom containers and legacy Docker networks without asking for confirmation. If you want to run the script with prompts, you can run it without the `-y` flag.
 
+**Selective Cleanup (New):**
+
+You can now target specific deployments for cleanup:
+
+```bash
+# Clean up specific slot ID
+./diagnose.sh -y -s 5483
+
+# Clean up specific chain
+./diagnose.sh -y -c mainnet
+
+# Clean up specific market
+./diagnose.sh -y -m uniswapv2
+
+# Combine filters
+./diagnose.sh -y -s 1234 -c devnet -m aavev3
+```
+
 The following output may vary depending on whether you have run snapshotter node(s) before this setup or not.
 
 ```

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -204,11 +204,24 @@ def diagnose(
     force: bool = typer.Option(
         False, "--force", "-f", help="Force cleanup without confirmation"
     ),
+    slot_id: Optional[str] = typer.Option(
+        None, "--slot-id", "-s", help="Filter by specific slot ID"
+    ),
+    chain: Optional[str] = typer.Option(
+        None, "--chain", help="Filter by chain name (e.g., 'mainnet', 'devnet')"
+    ),
+    market: Optional[str] = typer.Option(
+        None,
+        "--market",
+        "-m",
+        help="Filter by data market name (e.g., 'uniswapv2', 'aavev3')",
+    ),
 ):
     """
-    Run diagnostics on the system and optionally clean up existing deployments
+    Run diagnostics on the system and optionally clean up existing deployments.
+    Use filters to target specific slot IDs, chains, or markets.
     """
-    diagnose_command(clean, force)
+    diagnose_command(clean, force, slot_id=slot_id, chain=chain, market=market)
 
 
 @app.command()

--- a/snapshotter_cli/commands/shell.py
+++ b/snapshotter_cli/commands/shell.py
@@ -168,6 +168,9 @@ def get_missing_parameters(
                         console.print(
                             f"✅ Auto-selected source chain: [bold cyan]{value}[/bold cyan]"
                         )
+                    elif param_name == "slot_id" or param_name == "slot-id":
+                        # Prompt for slot ID (no special handling needed, just get input)
+                        value = Prompt.ask(f"\n[cyan]{param_help}[/cyan]")
                     elif param_name == "chain":
                         # Get available chains from CLI context
                         available_chains = ["MAINNET", "DEVNET"]

--- a/snapshotter_cli/utils/docker_utils.py
+++ b/snapshotter_cli/utils/docker_utils.py
@@ -22,7 +22,7 @@ def get_docker_container_status_for_instance(
     if not chain_name_upper or not market_name_upper:
         # slot_id might be missing if parsing failed, but chain/market are more critical for collector
         console.print(
-            "[dim]Skipping Docker search: chain name or market name not provided for filtering.[/dim]",
+            "[dim]Skipping Docker search: chain name or data market name not provided for filtering.[/dim]",
             style="yellow",
         )
         return containers


### PR DESCRIPTION
Fixes #89 

## Summary

Adds optional filtering to the `diagnose` cleanup command, allowing operators to target specific deployments instead of cleaning everything at once.

## Changes

### New Filter Options
- `--slot-id/-s`: Target specific slot ID
- `--chain`: Target specific chain (mainnet, devnet)
- `--market/-m`: Target specific market (uniswapv2, aavev3)

### Implementation
- **CLI**: `powerloom-snapshotter-cli diagnose --clean --slot-id 5483 --chain mainnet`
- **Shell Mode**: Works in interactive REPL
- **Legacy Script**: `./diagnose.sh -y -s 5483 -c mainnet -m uniswapv2`

### Files Changed
- `snapshotter_cli/commands/diagnose.py` - Core filtering logic
- `snapshotter_cli/cli.py` - CLI parameters
- `snapshotter_cli/commands/shell.py` - Shell mode support
- `diagnose.sh` - Legacy script support
- Documentation updates (CLI_DOCUMENTATION.md, README.md, CHANGELOG.md)

## Examples

```bash
# Clean specific slot
powerloom-snapshotter-cli diagnose --clean --slot-id 5483

# Clean specific chain + market
powerloom-snapshotter-cli diagnose --clean --chain mainnet --market uniswapv2

# Legacy script
./diagnose.sh -y -s 5483 -c devnet -m aavev3

# No filters = clean everything (backward compatible)
powerloom-snapshotter-cli diagnose --clean --force
```

## Testing
- ✅ All filters work case-insensitively
- ✅ Filters can be combined
- ✅ Backward compatible (no breaking changes)
- ✅ Works in CLI, shell, and legacy script
- ✅ All linting checks pass

## Impact
- **No breaking changes** - Existing commands work unchanged
- **Safer operations** - Reduces risk of accidentally terminating all deployments
- **Better control** - Operators can precisely target specific deployments