### PR TITLE
chore: release version 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Powerloom Snapshotter CLI and setup tools will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.1.6] - 2025-10-09
 
 ### Fixed
 - **Configure overwrite prompt (#88)** - Fixed issue where pressing any key other than 'y' or 'n' would abort configuration. Now re-prompts for valid input instead of aborting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "powerloom-snapshotter-cli"
-version = "0.1.5"
+version = "0.1.6"
 description = "CLI tool for deploying and managing Powerloom Snapshotter nodes"
 authors = [{name = "Powerloom Protocol", email = "hello@powerloom.io"}]
 readme = "PYPI_README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "powerloom-snapshotter-cli"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "psutil" },


### PR DESCRIPTION
- Updated version to 0.1.6 in pyproject.toml and uv.lock.
- Updated CHANGELOG to reflect the fix for the overwrite prompt handling in configuration, ensuring valid input is re-promoted instead of aborting.

