### PR TITLE
hotfix: legacy diagnosis script failing when passing a chain 

### DIFF
--- a/diagnose.sh
+++ b/diagnose.sh
@@ -323,13 +323,17 @@ if [ -n "$EXISTING_NETWORKS" ]; then
 
             for network in $EXISTING_NETWORKS; do
                 # Check if network has any connected containers
-                # Look for the "Containers": { section and check if it's empty or has entries
+                # Use docker network inspect and check if Containers is empty {}
                 NETWORK_INFO=$(docker network inspect "$network" 2>/dev/null || echo "")
                 if [ -n "$NETWORK_INFO" ]; then
-                    # Check if Containers section exists and has entries
-                    # Empty containers section looks like: "Containers": {},
-                    # Non-empty has entries like: "Containers": { "abc123...": { ... } },
-                    HAS_CONTAINERS=$(echo "$NETWORK_INFO" | grep -A2 '"Containers":' | grep -c '"Name":' || echo "0")
+                    # Check if the Containers section is empty
+                    # Empty: "Containers": {},
+                    # With containers: "Containers": { "id": {...} }
+                    if echo "$NETWORK_INFO" | grep -q '"Containers": {}'; then
+                        HAS_CONTAINERS="0"
+                    else
+                        HAS_CONTAINERS="1"
+                    fi
                 else
                     HAS_CONTAINERS="0"
                 fi


### PR DESCRIPTION
The problem was that grep -c was returning multiple lines, causing the integer
  comparison error at line 337.

  The new approach is simpler and more reliable:
  - It directly checks if the Containers section is empty ("Containers": {})
  - If empty → HAS_CONTAINERS=0 → Remove the network
  - If not empty → HAS_CONTAINERS=1 → Keep the network

  This avoids the counting issue and gives us a clean boolean check. The script should now correctly:
  1. Check each network for connected containers
  2. Only remove networks that are actually empty
  3. Keep networks that still have containers attached
  4. Provide clear feedback about what was kept vs removed