### PR TITLE
BDS and DSV mainnet rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **check_slots.py script** - Monitor deployment health by comparing owned slots vs running containers with detailed statistics
 - **BDS DSV Market Support** - Added support for `BDS_DEVNET_ALPHA_UNISWAPV3` and `BDS_MAINNET_UNISWAPV3` markets in deployment and CLI
 - **Commit ID Support** - Added support for config and compute packages commit IDs from sources.json in environment variables
-- **Deploy Command Slots Argument** - Added `--slots` argument to deploy command for comma-separated list of slot IDs
 - **Powerloom RPC URL Configuration** - Added Powerloom RPC URL prompt and selection process in configure command
 - **P2P Discovery and Connection Manager** - Added P2P Discovery and connection manager configuration for BDS-DSV deployments
 - **Centralized Sequencer Submission Switch** - Added support for centralized sequencer submission switch in local collector
 - **Active Profile Support in Deployment** - Added active profile support for environment configuration in deployment
 
 ### Changed
-- **BDS DSV Mainnet** - CLI and lite node use `--bds-dsv-mainnet` only for mainnet BDS; lite node no longer supports mainnet-alpha (`--bds-dsv-mainnet-alpha` removed). Mainnet market is `BDS_MAINNET_UNISWAPV3` with P2P prefix/rendezvous `dsv-mainnet-bds`.
+- **BDS DSV Mainnet** - CLI and lite node use `--bds-dsv-mainnet` for mainnet BDS; and `--bds-dsv-devnet` for devnet BDS. Mainnet market is `BDS_MAINNET_UNISWAPV3` with P2P prefix/rendezvous `dsv-mainnet-bds`. Devnet market is `BDS_DEVNET_ALPHA_UNISWAPV3` with P2P prefix/rendezvous `dsv-devnet-alpha`.
 - **Markets Config URL** - Updated MARKETS_CONFIG_URL to point to master branch of curated-datamarkets repository
 - **Gossipsub Configuration** - Refactored to parse gossipsub configuration from market config instead of hardcoded values
 - **Local Collector Repository Cloning** - Removed redundant local collector repository cloning from deployment logic (handled by lite node setup)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the Powerloom Snapshotter CLI and setup tools will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **BDS DSV Market Support** - Added support for `BDS_DEVNET_ALPHA_UNISWAPV3` and `BDS_MAINNET_UNISWAPV3` markets in deployment and CLI
+- **Commit ID Support** - Added support for config and compute packages commit IDs from sources.json in environment variables
+- **Deploy Command Slots Argument** - Added `--slots` argument to deploy command for comma-separated list of slot IDs
+- **Powerloom RPC URL Configuration** - Added Powerloom RPC URL prompt and selection process in configure command
+- **P2P Discovery and Connection Manager** - Added P2P Discovery and connection manager configuration for BDS-DSV deployments
+- **Centralized Sequencer Submission Switch** - Added support for centralized sequencer submission switch in local collector
+- **Active Profile Support in Deployment** - Added active profile support for environment configuration in deployment
+
+### Changed
+- **BDS DSV Mainnet** - CLI and lite node use `--bds-dsv-mainnet` only for mainnet BDS; lite node no longer supports mainnet-alpha (`--bds-dsv-mainnet-alpha` removed). Mainnet market is `BDS_MAINNET_UNISWAPV3` with P2P prefix/rendezvous `dsv-mainnet-bds`.
+- **Markets Config URL** - Updated MARKETS_CONFIG_URL to point to master branch of curated-datamarkets repository
+- **Gossipsub Configuration** - Refactored to parse gossipsub configuration from market config instead of hardcoded values
+- **Local Collector Repository Cloning** - Removed redundant local collector repository cloning from deployment logic (handled by lite node setup)
+
+### Fixed
+- **Configure Command Env Var Preservation** - Fixed configure command to preserve custom environment variables that are not part of the template
+- **Image Tags for BDS Markets** - Fixed enforcement of experimental image tags for LOCAL_COLLECTOR and IMAGE in BDS deployments
+- **Boolean Environment Variables** - Fixed normalization of boolean environment variables to lowercase for consistency
+- **POWERLOOM_CHAIN Variable** - Fixed POWERLOOM_CHAIN variable assignment in deployment
+
 ## [v0.2.0] - 2025-10-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -541,6 +541,39 @@ Sleeping for 30 seconds to allow docker containers to spin up...
 Sleeping for 10 seconds to allow docker containers to spin up...
 ```
 
+### BDS DSV Devnet Deployment
+
+For BDS DSV devnet deployments, the CLI automatically detects and applies BDS-specific configurations:
+
+```bash
+# Configure BDS DSV devnet (auto-selects BDS_DEVNET_ALPHA_UNISWAPV3)
+powerloom-snapshotter-cli configure --env devnet
+
+# Deploy with BDS optimizations automatically applied
+powerloom-snapshotter-cli deploy
+
+# The CLI automatically:
+# ✅ Uses --bds-dsv-devnet flag
+# ✅ Sets DEV_MODE=true, OVERRIDE_DEFAULTS=true, LOCAL_COLLECTOR_P2P_PORT=8001
+# ✅ Uses feat/bds_lite_dsv_rollout branch for lite node
+# ✅ Clones local collector with feat/gossipsub-submissions branch
+# ✅ Auto-selects BDS_DEVNET_ALPHA_UNISWAPV3 datamarket
+```
+
+**BDS DSV Devnet Features:**
+- **Zero Configuration**: No manual setup required for BDS deployments
+- **Auto-Selection**: Automatically selects BDS_DEVNET_ALPHA_UNISWAPV3 datamarket
+- **Optimized Defaults**: Pre-configured environment variables for best performance
+- **Proper Branches**: Uses correct branches for both lite node and local collector
+- **Enhanced Networking**: Multi-bootstrap support and proper P2P configuration
+
+When deploying BDS DSV devnet slots, you'll see output like:
+```
+🚀 BDS DSV Devnet market detected - using branch: feat/bds_lite_dsv_rollout
+✅ Local collector repo cloned and checked out to feat/gossipsub-submissions branch
+🔩 Deploying slot xxx1 for market BDS_DEVNET_ALPHA_UNISWAPV3
+```
+
 ## 3\. Monitoring\, diagnostics and cleanup
 
 The multi setup comes bundled with a diagnostic and cleanup script.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ powerloom-snapshotter-cli profile import updates.json --name wallet-alice --merg
 
 - [Multi node setup for multiple Powerloom Snapshotter Lite: Protocol V2 slot holders on Linux VPS](#multi-node-setup-for-multiple-powerloom-snapshotter-lite-protocol-v2-slot-holders-on-linux-vps)
   - [🚀 New: Powerloom Snapshotter CLI](#-new-powerloom-snapshotter-cli)
+    - [Quick Start with CLI](#quick-start-with-cli)
+    - [Recent CLI Improvements](#recent-cli-improvements)
+    - [🆕 Multi-Profile Support (v0.2.0+)](#-multi-profile-support-v020)
+      - [Profile Management Commands](#profile-management-commands)
+      - [Using Profiles](#using-profiles)
+      - [Export/Import Profiles](#exportimport-profiles)
+      - [Key Benefits](#key-benefits)
+    - [Key CLI Features](#key-cli-features)
   - [Table of Contents](#table-of-contents)
   - [1. Preparation](#1-preparation)
     - [1.1 Run Diagnostics to cleanup old instances](#11-run-diagnostics-to-cleanup-old-instances)
@@ -161,7 +169,10 @@ powerloom-snapshotter-cli profile import updates.json --name wallet-alice --merg
     - [2.1 Initialize Environment](#21-initialize-environment)
     - [2.2 Run the deploy script](#22-run-the-deploy-script)
       - [2.2.0 Deploy script command line flags](#220-deploy-script-command-line-flags)
+      - [Parallel Deployment](#parallel-deployment)
       - [2.2.1 Deploy a subset of slots](#221-deploy-a-subset-of-slots)
+        - [2.2.1.1 Deploy specific slots using --slots flag](#2211-deploy-specific-slots-using---slots-flag)
+        - [2.2.1.2 Deploy a subset using interactive mode](#2212-deploy-a-subset-using-interactive-mode)
       - [2.2.2 Deploy all slots](#222-deploy-all-slots)
   - [3. Monitoring, diagnostics and cleanup](#3-monitoring-diagnostics-and-cleanup)
     - [3.1 Cleanup\[optional\]](#31-cleanupoptional)
@@ -172,9 +183,16 @@ powerloom-snapshotter-cli profile import updates.json --name wallet-alice --merg
   - [4. Case studies](#4-case-studies)
     - [4.1 Deploy subsets of slots with different configs](#41-deploy-subsets-of-slots-with-different-configs)
     - [4.2 Running Slots from Different Wallets on a Single VPS](#42-running-slots-from-different-wallets-on-a-single-vps)
+    - [4.3 Managing Multiple Wallets with CLI Profiles (NEW!)](#43-managing-multiple-wallets-with-cli-profiles-new)
   - [Development and Build Instructions](#development-and-build-instructions)
     - [Building from Source](#building-from-source)
     - [Testing the Build](#testing-the-build)
+    - [Development Workflow](#development-workflow)
+    - [Development Guidelines](#development-guidelines)
+  - [Recent Improvements (2025-08-04)](#recent-improvements-2025-08-04)
+    - [Enhanced Shell Mode](#enhanced-shell-mode)
+    - [Streamlined Configuration](#streamlined-configuration)
+    - [Build and Compatibility](#build-and-compatibility)
 
 > [!NOTE]
 > This setup is for Lite nodes participating in the latest V2 of Powerloom Protocol with multiple data markets. [Protocol V1 setup](https://github.com/PowerLoom/snapshotter-lite-multi-setup/tree/master) is deprecated and its data markets are archived. Your submission data, rewards on it are finalized and recorded as [announced on Discord](https://discord.com/channels/777248105636560948/1146931631039463484/1242876184509812847).
@@ -583,39 +601,6 @@ Sleeping for 30 seconds to allow docker containers to spin up...
 🟠 Deploying node for slot xxx2 in data market UNISWAPV2
 ----------------------------------------Spinning up docker containers for slot xxx2----------------------------------------
 Sleeping for 10 seconds to allow docker containers to spin up...
-```
-
-### BDS DSV Devnet Deployment
-
-For BDS DSV devnet deployments, the CLI automatically detects and applies BDS-specific configurations:
-
-```bash
-# Configure BDS DSV devnet (auto-selects BDS_DEVNET_ALPHA_UNISWAPV3)
-powerloom-snapshotter-cli configure --env devnet
-
-# Deploy with BDS optimizations automatically applied
-powerloom-snapshotter-cli deploy
-
-# The CLI automatically:
-# ✅ Uses --bds-dsv-devnet flag
-# ✅ Sets DEV_MODE=true, OVERRIDE_DEFAULTS=true, LOCAL_COLLECTOR_P2P_PORT=8001
-# ✅ Uses feat/bds_lite_dsv_rollout branch for lite node
-# ✅ Clones local collector with feat/gossipsub-submissions branch
-# ✅ Auto-selects BDS_DEVNET_ALPHA_UNISWAPV3 datamarket
-```
-
-**BDS DSV Devnet Features:**
-- **Zero Configuration**: No manual setup required for BDS deployments
-- **Auto-Selection**: Automatically selects BDS_DEVNET_ALPHA_UNISWAPV3 datamarket
-- **Optimized Defaults**: Pre-configured environment variables for best performance
-- **Proper Branches**: Uses correct branches for both lite node and local collector
-- **Enhanced Networking**: Multi-bootstrap support and proper P2P configuration
-
-When deploying BDS DSV devnet slots, you'll see output like:
-```
-🚀 BDS DSV Devnet market detected - using branch: feat/bds_lite_dsv_rollout
-✅ Local collector repo cloned and checked out to feat/gossipsub-submissions branch
-🔩 Deploying slot xxx1 for market BDS_DEVNET_ALPHA_UNISWAPV3
 ```
 
 ## 3\. Monitoring\, diagnostics and cleanup

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -716,12 +716,16 @@ def deploy(
         # Get LITE_NODE_BRANCH from namespaced env content or use default
         lite_node_branch = "main"  # default branch
 
-        # Check if any selected market is BDS_DEVNET_ALPHA_UNISWAPV3 and set specific branch
-        bds_market_selected = any(market.name.upper() == "BDS_DEVNET_ALPHA_UNISWAPV3" for market in selected_market_objects)
+        # Check if any selected market is BDS_DEVNET_ALPHA_UNISWAPV3 or BDS_MAINNET_ALPHA_UNISWAPV3 and set specific branch
+        bds_market_selected = any(
+            market.name.upper() == "BDS_DEVNET_ALPHA_UNISWAPV3" 
+            or market.name.upper() == "BDS_MAINNET_ALPHA_UNISWAPV3" 
+            for market in selected_market_objects
+        )
         if bds_market_selected:
             lite_node_branch = "feat/bds_lite_dsv_rollout"
             console.print(
-                f"🚀 BDS DSV Devnet market detected - using branch: [bold cyan]{lite_node_branch}[/bold cyan]",
+                f"🚀 BDS DSV market detected - using branch: [bold cyan]{lite_node_branch}[/bold cyan]",
                 style="dim",
             )
         elif namespaced_env_content and "LITE_NODE_BRANCH" in namespaced_env_content:
@@ -927,6 +931,8 @@ def deploy(
                     data_market_number = "2"
                 elif market_name == "BDS_DEVNET_ALPHA_UNISWAPV3":
                     data_market_number = "1"
+                elif market_name == "BDS_MAINNET_ALPHA_UNISWAPV3":
+                    data_market_number = "1"
                 else:
                     # Default to 1 for unknown markets
                     data_market_number = "1"
@@ -940,6 +946,8 @@ def deploy(
                 # Add appropriate flag based on chain and market
                 if selected_powerloom_chain_name_upper == "DEVNET" and market_name == "BDS_DEVNET_ALPHA_UNISWAPV3":
                     build_sh_args_for_instance = f"--bds-dsv-devnet {base_args}"
+                elif selected_powerloom_chain_name_upper == "MAINNET" and market_name == "BDS_MAINNET_ALPHA_UNISWAPV3":
+                    build_sh_args_for_instance = f"--bds-dsv-mainnet-alpha {base_args}"
                 elif selected_powerloom_chain_name_upper == "DEVNET":
                     build_sh_args_for_instance = f"--devnet {base_args}"
                 else:

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -1312,7 +1312,19 @@ def list_chains_and_markets(ctx: typer.Context):
             market_branch_item.add(
                 f"[dim]Market Protocol State: {market_config_val.powerloomProtocolStateContractAddress}[/]"
             )
-            market_branch_item.add(f"[dim]Sequencer: {market_config_val.sequencer}[/]")
+            # P2P mesh info when centralized sequencer is off (False or unset)
+            if market_config_val.centralizedSequencerEnabled is not True and (
+                market_config_val.rendezvousPoint or market_config_val.gossipsubSnapshotSubmissionPrefix
+            ):
+                market_branch_item.add("[dim]P2P mesh (centralized sequencer off)[/]")
+                if market_config_val.rendezvousPoint:
+                    market_branch_item.add(
+                        f"[dim]  Rendezvous: {market_config_val.rendezvousPoint}[/]"
+                    )
+                if market_config_val.gossipsubSnapshotSubmissionPrefix:
+                    market_branch_item.add(
+                        f"[dim]  Gossipsub prefix: {market_config_val.gossipsubSnapshotSubmissionPrefix}[/]"
+                    )
             market_branch_item.add(
                 f"[dim]Compute: {str(market_config_val.compute.repo)} ({market_config_val.compute.branch}) Commit: {market_config_val.compute.commit[:7] if market_config_val.compute.commit else 'N/A'}[/]"
             )

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -715,7 +715,16 @@ def deploy(
 
         # Get LITE_NODE_BRANCH from namespaced env content or use default
         lite_node_branch = "main"  # default branch
-        if namespaced_env_content and "LITE_NODE_BRANCH" in namespaced_env_content:
+
+        # Check if any selected market is BDS_DEVNET_ALPHA_UNISWAPV3 and set specific branch
+        bds_market_selected = any(market.name.upper() == "BDS_DEVNET_ALPHA_UNISWAPV3" for market in selected_market_objects)
+        if bds_market_selected:
+            lite_node_branch = "feat/bds_lite_dsv_rollout"
+            console.print(
+                f"🚀 BDS DSV Devnet market detected - using branch: [bold cyan]{lite_node_branch}[/bold cyan]",
+                style="dim",
+            )
+        elif namespaced_env_content and "LITE_NODE_BRANCH" in namespaced_env_content:
             lite_node_branch = namespaced_env_content["LITE_NODE_BRANCH"]
             console.print(
                 f"📌 Using LITE_NODE_BRANCH from configuration: [bold cyan]{lite_node_branch}[/bold cyan]",
@@ -916,6 +925,8 @@ def deploy(
                     data_market_number = "1"
                 elif market_name == "UNISWAPV2":
                     data_market_number = "2"
+                elif market_name == "BDS_DEVNET_ALPHA_UNISWAPV3":
+                    data_market_number = "1"
                 else:
                     # Default to 1 for unknown markets
                     data_market_number = "1"
@@ -925,8 +936,10 @@ def deploy(
                     f"{base_args} --data-market-contract-number {data_market_number}"
                 )
 
-                # Add --devnet flag if deploying to devnet
-                if selected_powerloom_chain_name_upper == "DEVNET":
+                # Add appropriate flag based on chain and market
+                if selected_powerloom_chain_name_upper == "DEVNET" and market_name == "BDS_DEVNET_ALPHA_UNISWAPV3":
+                    build_sh_args_for_instance = f"--bds-dsv-devnet {base_args}"
+                elif selected_powerloom_chain_name_upper == "DEVNET":
                     build_sh_args_for_instance = f"--devnet {base_args}"
                 else:
                     build_sh_args_for_instance = base_args

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -966,6 +966,7 @@ def deploy(
                     source_chain_rpc_url=source_rpc_url,
                     base_snapshotter_lite_repo_path=base_snapshotter_clone_path,
                     build_sh_args_param=build_sh_args_for_instance,
+                    active_profile=active_profile,
                 )
                 if success:
                     successful_deployments += 1

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -40,7 +40,7 @@ from .utils.models import (
 from .utils.system_checks import is_docker_running, list_snapshotter_screen_sessions
 
 MARKETS_CONFIG_URL = (
-    "https://raw.githubusercontent.com/powerloom/curated-datamarkets/refs/heads/chore/mod-dsv-devnet-bootstrap/sources.json"
+    "https://raw.githubusercontent.com/powerloom/curated-datamarkets/refs/heads/master/sources.json"
 )
 
 

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -40,7 +40,7 @@ from .utils.models import (
 from .utils.system_checks import is_docker_running, list_snapshotter_screen_sessions
 
 MARKETS_CONFIG_URL = (
-    "https://raw.githubusercontent.com/powerloom/curated-datamarkets/main/sources.json"
+    "https://raw.githubusercontent.com/powerloom/curated-datamarkets/chore/mod-dsv-devnet-bootstrap/sources.json"
 )
 
 

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -762,10 +762,10 @@ def deploy(
         # Get LITE_NODE_BRANCH from namespaced env content or use default
         lite_node_branch = "main"  # default branch
 
-        # Check if any selected market is BDS_DEVNET_ALPHA_UNISWAPV3 or BDS_MAINNET_ALPHA_UNISWAPV3 and set specific branch
+        # Check if any selected market is BDS_DEVNET_ALPHA_UNISWAPV3 or BDS_MAINNET_UNISWAPV3 and set specific branch
         bds_market_selected = any(
             market.name.upper() == "BDS_DEVNET_ALPHA_UNISWAPV3" 
-            or market.name.upper() == "BDS_MAINNET_ALPHA_UNISWAPV3" 
+            or market.name.upper() == "BDS_MAINNET_UNISWAPV3" 
             for market in selected_market_objects
         )
         if bds_market_selected:
@@ -977,7 +977,7 @@ def deploy(
                     data_market_number = "2"
                 elif market_name == "BDS_DEVNET_ALPHA_UNISWAPV3":
                     data_market_number = "1"
-                elif market_name == "BDS_MAINNET_ALPHA_UNISWAPV3":
+                elif market_name == "BDS_MAINNET_UNISWAPV3":
                     data_market_number = "1"
                 else:
                     # Default to 1 for unknown markets
@@ -992,8 +992,8 @@ def deploy(
                 # Add appropriate flag based on chain and market
                 if selected_powerloom_chain_name_upper == "DEVNET" and market_name == "BDS_DEVNET_ALPHA_UNISWAPV3":
                     build_sh_args_for_instance = f"--bds-dsv-devnet {base_args}"
-                elif selected_powerloom_chain_name_upper == "MAINNET" and market_name == "BDS_MAINNET_ALPHA_UNISWAPV3":
-                    build_sh_args_for_instance = f"--bds-dsv-mainnet-alpha {base_args}"
+                elif selected_powerloom_chain_name_upper == "MAINNET" and market_name == "BDS_MAINNET_UNISWAPV3":
+                    build_sh_args_for_instance = f"--bds-dsv-mainnet {base_args}"
                 elif selected_powerloom_chain_name_upper == "DEVNET":
                     build_sh_args_for_instance = f"--devnet {base_args}"
                 else:

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -769,7 +769,7 @@ def deploy(
             for market in selected_market_objects
         )
         if bds_market_selected:
-            lite_node_branch = "feat/bds_lite_dsv_rollout"
+            lite_node_branch = "master"
             console.print(
                 f"🚀 BDS DSV market detected - using branch: [bold cyan]{lite_node_branch}[/bold cyan]",
                 style="dim",

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -39,9 +39,7 @@ from .utils.models import (
 )
 from .utils.system_checks import is_docker_running, list_snapshotter_screen_sessions
 
-MARKETS_CONFIG_URL = (
-    "https://raw.githubusercontent.com/powerloom/curated-datamarkets/refs/heads/master/sources.json"
-)
+MARKETS_CONFIG_URL = "https://raw.githubusercontent.com/powerloom/curated-datamarkets/refs/heads/master/sources.json"
 
 
 def parse_selection_string(selection: str, max_value: int) -> List[int]:
@@ -764,8 +762,8 @@ def deploy(
 
         # Check if any selected market is BDS_DEVNET_ALPHA_UNISWAPV3 or BDS_MAINNET_UNISWAPV3 and set specific branch
         bds_market_selected = any(
-            market.name.upper() == "BDS_DEVNET_ALPHA_UNISWAPV3" 
-            or market.name.upper() == "BDS_MAINNET_UNISWAPV3" 
+            market.name.upper() == "BDS_DEVNET_ALPHA_UNISWAPV3"
+            or market.name.upper() == "BDS_MAINNET_UNISWAPV3"
             for market in selected_market_objects
         )
         if bds_market_selected:
@@ -988,11 +986,16 @@ def deploy(
                     f"{base_args} --data-market-contract-number {data_market_number}"
                 )
 
-                
                 # Add appropriate flag based on chain and market
-                if selected_powerloom_chain_name_upper == "DEVNET" and market_name == "BDS_DEVNET_ALPHA_UNISWAPV3":
+                if (
+                    selected_powerloom_chain_name_upper == "DEVNET"
+                    and market_name == "BDS_DEVNET_ALPHA_UNISWAPV3"
+                ):
                     build_sh_args_for_instance = f"--bds-dsv-devnet {base_args}"
-                elif selected_powerloom_chain_name_upper == "MAINNET" and market_name == "BDS_MAINNET_UNISWAPV3":
+                elif (
+                    selected_powerloom_chain_name_upper == "MAINNET"
+                    and market_name == "BDS_MAINNET_UNISWAPV3"
+                ):
                     build_sh_args_for_instance = f"--bds-dsv-mainnet {base_args}"
                 elif selected_powerloom_chain_name_upper == "DEVNET":
                     build_sh_args_for_instance = f"--devnet {base_args}"
@@ -1675,7 +1678,8 @@ def list_chains_and_markets(ctx: typer.Context):
             )
             # P2P mesh info when centralized sequencer is off (False or unset)
             if market_config_val.centralizedSequencerEnabled is not True and (
-                market_config_val.rendezvousPoint or market_config_val.gossipsubSnapshotSubmissionPrefix
+                market_config_val.rendezvousPoint
+                or market_config_val.gossipsubSnapshotSubmissionPrefix
             ):
                 market_branch_item.add("[dim]P2P mesh (centralized sequencer off)[/]")
                 if market_config_val.rendezvousPoint:

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -39,7 +39,7 @@ from .utils.models import (
 )
 from .utils.system_checks import is_docker_running, list_snapshotter_screen_sessions
 
-MARKETS_CONFIG_URL = "https://raw.githubusercontent.com/powerloom/curated-datamarkets/refs/heads/master/sources.json"
+MARKETS_CONFIG_URL = "https://raw.githubusercontent.com/powerloom/curated-datamarkets/master/sources.json"
 
 
 def parse_selection_string(selection: str, max_value: int) -> List[int]:

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -40,7 +40,7 @@ from .utils.models import (
 from .utils.system_checks import is_docker_running, list_snapshotter_screen_sessions
 
 MARKETS_CONFIG_URL = (
-    "https://raw.githubusercontent.com/powerloom/curated-datamarkets/master/sources.json"
+    "https://raw.githubusercontent.com/powerloom/curated-datamarkets/refs/heads/chore/mod-dsv-devnet-bootstrap/sources.json"
 )
 
 

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -936,6 +936,7 @@ def deploy(
                     f"{base_args} --data-market-contract-number {data_market_number}"
                 )
 
+                
                 # Add appropriate flag based on chain and market
                 if selected_powerloom_chain_name_upper == "DEVNET" and market_name == "BDS_DEVNET_ALPHA_UNISWAPV3":
                     build_sh_args_for_instance = f"--bds-dsv-devnet {base_args}"

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -40,7 +40,7 @@ from .utils.models import (
 from .utils.system_checks import is_docker_running, list_snapshotter_screen_sessions
 
 MARKETS_CONFIG_URL = (
-    "https://raw.githubusercontent.com/powerloom/curated-datamarkets/chore/mod-dsv-devnet-bootstrap/sources.json"
+    "https://raw.githubusercontent.com/powerloom/curated-datamarkets/master/sources.json"
 )
 
 

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -151,6 +151,9 @@ def configure_command(
     chain_config = chain_data.chain_config
     default_rpc_url = str(chain_config.rpcURL).rstrip("/")
 
+    # Initialize existing_env_vars early (will be loaded later after market selection)
+    existing_env_vars = {}
+
     # --- Select Powerloom RPC URL (namespaced env takes precedence over chain default) ---
     if powerloom_rpc_url:
         final_powerloom_rpc_url = powerloom_rpc_url

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -147,28 +147,10 @@ def configure_command(
     # --- Select Data Market ---
     chain_data = cli_context.chain_markets_map[selected_chain_name_upper]
 
-    # --- Get Powerloom RPC URL from chain config ---
+    # --- Get Powerloom RPC URL from chain config (used as fallback) ---
     chain_config = chain_data.chain_config
     default_rpc_url = str(chain_config.rpcURL).rstrip("/")
 
-    # Initialize existing_env_vars early (will be loaded later after market selection)
-    existing_env_vars = {}
-
-    # --- Select Powerloom RPC URL (namespaced env takes precedence over chain default) ---
-    if powerloom_rpc_url:
-        final_powerloom_rpc_url = powerloom_rpc_url
-    elif existing_env_vars.get("POWERLOOM_RPC_URL"):
-        final_powerloom_rpc_url = existing_env_vars.get("POWERLOOM_RPC_URL", "").strip()
-        console.print(
-            f"✅ Using Powerloom RPC URL from existing config: [bold cyan]{final_powerloom_rpc_url}[/bold cyan]",
-            style="green",
-        )
-    else:
-        final_powerloom_rpc_url = default_rpc_url
-        console.print(
-            f"✅ Using default Powerloom RPC URL: [bold cyan]{default_rpc_url}[/bold cyan]",
-            style="green",
-        )
     available_markets = sorted(chain_data.markets.keys())
     if not available_markets:
         console.print(
@@ -315,6 +297,19 @@ def configure_command(
         f"👉 Enter RPC URL for {selected_market_obj.sourceChain}",
         default=existing_env_vars.get("SOURCE_RPC_URL", ""),
     )
+    # Prompt for Powerloom RPC URL (existing env takes precedence over chain default)
+    if powerloom_rpc_url:
+        final_powerloom_rpc_url = powerloom_rpc_url
+        console.print(
+            f"✅ Using Powerloom RPC URL from CLI: [bold cyan]{final_powerloom_rpc_url}[/bold cyan]",
+            style="green",
+        )
+    else:
+        existing_powerloom_rpc = existing_env_vars.get("POWERLOOM_RPC_URL", "").strip()
+        final_powerloom_rpc_url = Prompt.ask(
+            "👉 Enter Powerloom RPC URL",
+            default=existing_powerloom_rpc or default_rpc_url,
+        )
     final_telegram_chat = telegram_chat_id or Prompt.ask(
         "👉 Enter Telegram chat ID (optional)",
         default=existing_env_vars.get("TELEGRAM_CHAT_ID", ""),

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -371,15 +371,16 @@ def configure_command(
             default=existing_env_vars.get("LOCAL_COLLECTOR_P2P_PORT", "8001"),
         )
     )
-    
+
     # Start with all existing env vars to preserve any that aren't part of the template
     # This prevents overwriting custom env vars like LOCAL_COLLECTOR_HEALTH_CHECK_PORT
     # Filter out None values (dotenv_values returns None for missing keys)
     final_env_vars = {
-        k: v for k, v in (existing_env_vars.items() if existing_env_vars else {})
+        k: v
+        for k, v in (existing_env_vars.items() if existing_env_vars else {})
         if v is not None
     }
-    
+
     # Update only the configured fields (merge approach)
     if final_wallet_address:
         final_env_vars["WALLET_HOLDER_ADDRESS"] = final_wallet_address
@@ -400,7 +401,9 @@ def configure_command(
     if final_max_stream_pool_size:
         final_env_vars["MAX_STREAM_POOL_SIZE"] = final_max_stream_pool_size
     if final_connection_refresh_interval:
-        final_env_vars["CONNECTION_REFRESH_INTERVAL_SEC"] = final_connection_refresh_interval
+        final_env_vars["CONNECTION_REFRESH_INTERVAL_SEC"] = (
+            final_connection_refresh_interval
+        )
     if final_powerloom_rpc_url:
         final_env_vars["POWERLOOM_RPC_URL"] = final_powerloom_rpc_url
     if final_local_collector_p2p_port:
@@ -409,7 +412,7 @@ def configure_command(
     # Set default values for LITE_NODE_BRANCH and LOCAL_COLLECTOR_IMAGE_TAG if not present
     final_env_vars.setdefault("LITE_NODE_BRANCH", "main")
     final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "latest")
-    
+
     # Build env_contents list from the merged dict for display and writing
     env_contents = []
     # Define the order for template fields (for consistent output)
@@ -429,12 +432,12 @@ def configure_command(
         "LITE_NODE_BRANCH",
         "LOCAL_COLLECTOR_IMAGE_TAG",
     ]
-    
+
     # Add template fields in order
     for key in template_field_order:
         if key in final_env_vars and final_env_vars[key] is not None:
             env_contents.append(f"{key}={final_env_vars[key]}")
-    
+
     # Add any remaining env vars that aren't in the template (preserve custom vars)
     for key, value in sorted(final_env_vars.items()):
         if key not in template_field_order and value is not None:

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -275,8 +275,10 @@ def deploy_snapshotter_instance(
             market_config.gossipsubSnapshotSubmissionPrefix,
         )
     if market_config.centralizedSequencerEnabled is not None:
+        # Convert boolean to lowercase string
+        centralized_seq_enabled_str = str(market_config.centralizedSequencerEnabled).lower()
         final_env_vars.setdefault(
-            "CENTRALIZED_SEQUENCER_ENABLED", market_config.centralizedSequencerEnabled
+            "CENTRALIZED_SEQUENCER_ENABLED", centralized_seq_enabled_str
         )
 
     # Add BDS-specific environment variables for BDS_DEVNET_ALPHA_UNISWAPV3
@@ -440,7 +442,8 @@ def deploy_snapshotter_instance(
     ]
     for var in boolean_env_vars:
         if var in final_env_vars:
-            final_env_vars[var] = final_env_vars[var].lower()
+            # Convert to string first (handles bool values from market_config), then lowercase
+            final_env_vars[var] = str(final_env_vars[var]).lower()
 
     # TELEGRAM_REPORTING_URL and TELEGRAM_CHAT_ID will be included if they were in the pre-configured .env
     # or global env vars that got loaded into namespaced_env_content (passed to get_credential originally).

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -294,7 +294,8 @@ def deploy_snapshotter_instance(
         "BDS_DEVNET_ALPHA_UNISWAPV3",
         "BDS_MAINNET_UNISWAPV3",
     ):
-        # For BDS deployments, force local collector image tag to master
+        # For BDS deployments, force lite node and local collector image tags to master
+        final_env_vars["IMAGE_TAG"] = "master"
         final_env_vars["LOCAL_COLLECTOR_IMAGE_TAG"] = "master"
         final_env_vars.setdefault("LOCAL_COLLECTOR_P2P_PORT", "8001")
         # Health check port for local collector (default: 8080, can be overridden in pre-configured env)

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -245,7 +245,9 @@ def deploy_snapshotter_instance(
     # Add BDS-specific environment variables for BDS_DEVNET_ALPHA_UNISWAPV3
     if market_config.name.upper() == "BDS_DEVNET_ALPHA_UNISWAPV3":
         final_env_vars["DEV_MODE"] = "true"
-        final_env_vars["LOCAL_COLLECTOR_P2P_PORT"] = "8001"
+        final_env_vars.setdefault("LOCAL_COLLECTOR_P2P_PORT", "8001")
+        # Health check port for local collector (default: 8080, can be overridden in pre-configured env)
+        final_env_vars.setdefault("LOCAL_COLLECTOR_HEALTH_CHECK_PORT", "8080")
         # P2P Discovery configuration for DSV devnet
         final_env_vars["RENDEZVOUS_POINT"] = "powerloom-dsv-devnet-alpha"
         final_env_vars["GOSSIPSUB_SNAPSHOT_SUBMISSION_PREFIX"] = "/powerloom/dsv-devnet-alpha/snapshot-submissions"
@@ -298,7 +300,9 @@ def deploy_snapshotter_instance(
         final_env_vars["PUBLIC_IP"] = ""
     elif market_config.name.upper() == "BDS_MAINNET_ALPHA_UNISWAPV3":
         final_env_vars["DEV_MODE"] = "true"
-        final_env_vars["LOCAL_COLLECTOR_P2P_PORT"] = "8001"
+        final_env_vars.setdefault("LOCAL_COLLECTOR_P2P_PORT", "8001")
+        # Health check port for local collector (default: 8080, can be overridden in pre-configured env)
+        final_env_vars.setdefault("LOCAL_COLLECTOR_HEALTH_CHECK_PORT", "8080")
         # P2P Discovery configuration for DSV mainnet
         final_env_vars["RENDEZVOUS_POINT"] = "powerloom-dsv-mainnet-alpha"
         final_env_vars["GOSSIPSUB_SNAPSHOT_SUBMISSION_PREFIX"] = "/powerloom/dsv-mainnet-alpha/snapshot-submissions"

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -300,7 +300,8 @@ def deploy_snapshotter_instance(
 
     # Add missing vars from multi_clone.py, using defaults or loading from pre-config/env
     # For simplicity, pre-loaded 'final_env_vars' from a namespaced .env file can override these defaults.
-    final_env_vars.setdefault("LOCAL_COLLECTOR_PORT", "50051")
+    # Note: LOCAL_COLLECTOR_PORT is not set here to avoid port conflicts in multi-instance deployments
+    # The collector_test.sh will handle port allocation for the first instance
     final_env_vars.setdefault(
         "MAX_STREAM_POOL_SIZE", "2"
     )  # Default from multi_clone, may need adjustment based on CPU as in multi_clone

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -292,7 +292,7 @@ def deploy_snapshotter_instance(
     final_env_vars["SNAPSHOTTER_COMPUTE_REPO"] = str(market_config.compute.repo)
     final_env_vars["SNAPSHOTTER_COMPUTE_REPO_BRANCH"] = market_config.compute.branch
 
-    final_env_vars["POWERLOOM_CHAIN"] = pl_chain_name_upper
+    final_env_vars["POWERLOOM_CHAIN"] = norm_pl_chain_name
     final_env_vars["NAMESPACE"] = market_name_upper
     final_env_vars["SOURCE_CHAIN"] = source_chain_prefix_upper
     final_env_vars["FULL_NAMESPACE"] = env_file_suffix

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -429,6 +429,18 @@ def deploy_snapshotter_instance(
     )  # Simplified default
     final_env_vars.setdefault("CONNECTION_REFRESH_INTERVAL_SEC", "60")
     final_env_vars.setdefault("TELEGRAM_NOTIFICATION_COOLDOWN", "300")
+    
+    # Normalize boolean env vars to lowercase AFTER all values are set
+    # This handles cases where env files have "False" or "True" instead of "false" or "true"
+    # Go's strconv.ParseBool is case-insensitive, but normalizing ensures consistency
+    boolean_env_vars = [
+        "CENTRALIZED_SEQUENCER_ENABLED",
+        "DEV_MODE",
+        "DATA_MARKET_IN_REQUEST",
+    ]
+    for var in boolean_env_vars:
+        if var in final_env_vars:
+            final_env_vars[var] = final_env_vars[var].lower()
 
     # TELEGRAM_REPORTING_URL and TELEGRAM_CHAT_ID will be included if they were in the pre-configured .env
     # or global env vars that got loaded into namespaced_env_content (passed to get_credential originally).

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -300,8 +300,7 @@ def deploy_snapshotter_instance(
 
     # Add missing vars from multi_clone.py, using defaults or loading from pre-config/env
     # For simplicity, pre-loaded 'final_env_vars' from a namespaced .env file can override these defaults.
-    # Note: LOCAL_COLLECTOR_PORT is not set here to avoid port conflicts in multi-instance deployments
-    # The collector_test.sh will handle port allocation for the first instance
+    final_env_vars.setdefault("LOCAL_COLLECTOR_PORT", "50051")
     final_env_vars.setdefault(
         "MAX_STREAM_POOL_SIZE", "2"
     )  # Default from multi_clone, may need adjustment based on CPU as in multi_clone

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -348,8 +348,10 @@ def deploy_snapshotter_instance(
         # Note: DEV_MODE not forced - user controls via namespaced env file
         # Set DEV_MODE=true in namespaced env to build from source instead of using pre-built images
         # For production deployments (DEV_MODE not set), use experimental tag for pre-built images
-        final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "experimental")
-        final_env_vars.setdefault("IMAGE_TAG", "experimental")
+        # FOR MAINNET ALPHA, we are forcefully setting both lite node and local collector to experimental tag
+        # even if the namepsaced env file specifies other tags.
+        final_env_vars['LOCAL_COLLECTOR_IMAGE_TAG'] = "experimental"
+        final_env_vars['IMAGE_TAG'] = "experimental"
         final_env_vars.setdefault("LOCAL_COLLECTOR_P2P_PORT", "8001")
         # Health check port for local collector (default: 8080, can be overridden in pre-configured env)
         final_env_vars.setdefault("LOCAL_COLLECTOR_HEALTH_CHECK_PORT", "8080")

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -260,8 +260,24 @@ def deploy_snapshotter_instance(
     final_env_vars["SLOT_ID"] = str(slot_id)
     final_env_vars["SIGNER_ACCOUNT_ADDRESS"] = signer_address
     final_env_vars["SIGNER_ACCOUNT_PRIVATE_KEY"] = signer_private_key
-    final_env_vars["POWERLOOM_RPC_URL"] = str(powerloom_chain_config.rpcURL).rstrip("/")
+    # Namespaced env takes precedence; otherwise use chain config
+    final_env_vars.setdefault(
+        "POWERLOOM_RPC_URL", str(powerloom_chain_config.rpcURL).rstrip("/")
+    )
     final_env_vars["SOURCE_RPC_URL"] = source_chain_rpc_url
+
+    # Apply mesh/P2P defaults from market config when present (namespaced env still wins)
+    if market_config.rendezvousPoint:
+        final_env_vars.setdefault("RENDEZVOUS_POINT", market_config.rendezvousPoint)
+    if market_config.gossipsubSnapshotSubmissionPrefix:
+        final_env_vars.setdefault(
+            "GOSSIPSUB_SNAPSHOT_SUBMISSION_PREFIX",
+            market_config.gossipsubSnapshotSubmissionPrefix,
+        )
+    if market_config.centralizedSequencerEnabled is not None:
+        final_env_vars.setdefault(
+            "CENTRALIZED_SEQUENCER_ENABLED", market_config.centralizedSequencerEnabled
+        )
 
     # Add BDS-specific environment variables for BDS_DEVNET_ALPHA_UNISWAPV3
     if market_config.name.upper() == "BDS_DEVNET_ALPHA_UNISWAPV3":
@@ -269,9 +285,12 @@ def deploy_snapshotter_instance(
         final_env_vars.setdefault("LOCAL_COLLECTOR_P2P_PORT", "8001")
         # Health check port for local collector (default: 8080, can be overridden in pre-configured env)
         final_env_vars.setdefault("LOCAL_COLLECTOR_HEALTH_CHECK_PORT", "8080")
-        # P2P Discovery configuration for DSV devnet
-        final_env_vars["RENDEZVOUS_POINT"] = "powerloom-dsv-devnet-alpha"
-        final_env_vars["GOSSIPSUB_SNAPSHOT_SUBMISSION_PREFIX"] = "/powerloom/dsv-devnet-alpha/snapshot-submissions"
+        # P2P Discovery (market config or namespaced env override these when set)
+        final_env_vars.setdefault("RENDEZVOUS_POINT", "powerloom-dsv-devnet-alpha")
+        final_env_vars.setdefault(
+            "GOSSIPSUB_SNAPSHOT_SUBMISSION_PREFIX",
+            "/powerloom/dsv-devnet-alpha/snapshot-submissions",
+        )
         
         # Extract bootstrap nodes from market config (from curated datamarkets JSON)
         if market_config.bootstrapNodes and len(market_config.bootstrapNodes) > 0:
@@ -303,7 +322,7 @@ def deploy_snapshotter_instance(
         # Centralized Sequencer Control
         # Set to "false" to disable all submissions to centralized sequencer (mesh-only mode)
         # Set to "true" to enable dual submission (both centralized sequencer and mesh)
-        final_env_vars["CENTRALIZED_SEQUENCER_ENABLED"] = "false"
+        final_env_vars.setdefault("CENTRALIZED_SEQUENCER_ENABLED", "false")
         
         # Mesh Submission Concurrency Controls
         # Rate limiting for mesh submissions to prevent overwhelming the gossipsub network
@@ -324,9 +343,12 @@ def deploy_snapshotter_instance(
         final_env_vars.setdefault("LOCAL_COLLECTOR_P2P_PORT", "8001")
         # Health check port for local collector (default: 8080, can be overridden in pre-configured env)
         final_env_vars.setdefault("LOCAL_COLLECTOR_HEALTH_CHECK_PORT", "8080")
-        # P2P Discovery configuration for DSV mainnet
-        final_env_vars["RENDEZVOUS_POINT"] = "powerloom-dsv-mainnet-alpha"
-        final_env_vars["GOSSIPSUB_SNAPSHOT_SUBMISSION_PREFIX"] = "/powerloom/dsv-mainnet-alpha/snapshot-submissions"
+        # P2P Discovery (market config or namespaced env override these when set)
+        final_env_vars.setdefault("RENDEZVOUS_POINT", "powerloom-dsv-mainnet-alpha")
+        final_env_vars.setdefault(
+            "GOSSIPSUB_SNAPSHOT_SUBMISSION_PREFIX",
+            "/powerloom/dsv-mainnet-alpha/snapshot-submissions",
+        )
         
         # Extract bootstrap nodes from market config (from curated datamarkets JSON)
         if market_config.bootstrapNodes and len(market_config.bootstrapNodes) > 0:
@@ -358,7 +380,7 @@ def deploy_snapshotter_instance(
         # Centralized Sequencer Control
         # Set to "false" to disable all submissions to centralized sequencer (mesh-only mode)
         # Set to "true" to enable dual submission (both centralized sequencer and mesh)
-        final_env_vars["CENTRALIZED_SEQUENCER_ENABLED"] = "false"
+        final_env_vars.setdefault("CENTRALIZED_SEQUENCER_ENABLED", "false")
         
         # Mesh Submission Concurrency Controls
         # Rate limiting for mesh submissions to prevent overwhelming the gossipsub network

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -186,76 +186,7 @@ def deploy_snapshotter_instance(
         console.print(
             f"    ✅ Base snapshotter copied successfully.", style="dim green"
         )
-
-        # 3. Clone local collector repository for BDS deployments
-        if market_config.name.upper() == "BDS_DEVNET_ALPHA_UNISWAPV3":
-            console.print(
-                "  🔗 Cloning local collector repository for BDS deployment...",
-                style="dim",
-            )
-            try:
-                local_collector_repo_url = "https://github.com/powerloom/snapshotter-lite-local-collector.git"
-                local_collector_dir = instance_dir / "snapshotter-lite-local-collector"
-
-                # Clone the repository
-                subprocess.run(
-                    ["git", "clone", local_collector_repo_url, str(local_collector_dir)],
-                    check=True,
-                    capture_output=True,
-                )
-
-                # Checkout the specific branch
-                subprocess.run(
-                    ["git", "checkout", "dsv-p2p"],
-                    check=True,
-                    capture_output=True,
-                    cwd=str(local_collector_dir),
-                )
-
-                console.print(
-                    "    ✅ Local collector repo cloned and checked out to dsv-p2p branch",
-                    style="dim green",
-                )
-            except Exception as e:
-                console.print(
-                    f"    ❌ Failed to clone local collector repository: {e}",
-                    style="bold red",
-                )
-                return False
-        elif market_config.name.upper() == "BDS_MAINNET_ALPHA_UNISWAPV3":
-            console.print(
-                "  🔗 Cloning local collector repository for BDS deployment...",
-                style="dim",
-            )
-            try:
-                local_collector_repo_url = "https://github.com/powerloom/snapshotter-lite-local-collector.git"
-                local_collector_dir = instance_dir / "snapshotter-lite-local-collector"
-
-                # Clone the repository
-                subprocess.run(
-                    ["git", "clone", local_collector_repo_url, str(local_collector_dir)],
-                    check=True,
-                    capture_output=True,
-                )
-
-                # Checkout the specific branch
-                subprocess.run(
-                    ["git", "checkout", "feat/dsv-p2p-autorelay-central-seq-off"],
-                    check=True,
-                    capture_output=True,
-                    cwd=str(local_collector_dir),
-                )
-
-                console.print(
-                    "    ✅ Local collector repo cloned and checked out to feat/dsv-p2p-autorelay-central-seq-off branch",
-                    style="dim green",
-                )
-            except Exception as e:
-                console.print(
-                    f"    ❌ Failed to clone local collector repository: {e}",
-                    style="bold red",
-                )
-                return False
+        # Note: Local collector repository cloning is handled by build.sh, not here
     except Exception as e:
         console.print(
             f"  ❌ Error copying base snapshotter files from {base_snapshotter_lite_repo_path} to {instance_dir}: {e}",

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -415,9 +415,15 @@ def deploy_snapshotter_instance(
     )
     final_env_vars["SNAPSHOT_CONFIG_REPO"] = str(market_config.config.repo)
     final_env_vars["SNAPSHOT_CONFIG_REPO_BRANCH"] = market_config.config.branch
+    # Set commit ID if available (from sources.json)
+    if market_config.config.commit:
+        final_env_vars["SNAPSHOT_CONFIG_REPO_COMMIT"] = market_config.config.commit
 
     final_env_vars["SNAPSHOTTER_COMPUTE_REPO"] = str(market_config.compute.repo)
     final_env_vars["SNAPSHOTTER_COMPUTE_REPO_BRANCH"] = market_config.compute.branch
+    # Set commit ID if available (from sources.json)
+    if market_config.compute.commit:
+        final_env_vars["SNAPSHOTTER_COMPUTE_REPO_COMMIT"] = market_config.compute.commit
 
     final_env_vars["POWERLOOM_CHAIN"] = norm_pl_chain_name
     final_env_vars["NAMESPACE"] = market_name_upper

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -294,8 +294,8 @@ def deploy_snapshotter_instance(
         "BDS_DEVNET_ALPHA_UNISWAPV3",
         "BDS_MAINNET_UNISWAPV3",
     ):
-        # Default BDS local collector image tag to master (namespaced env can override)
-        final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "master")
+        # For BDS deployments, force local collector image tag to master
+        final_env_vars["LOCAL_COLLECTOR_IMAGE_TAG"] = "master"
         final_env_vars.setdefault("LOCAL_COLLECTOR_P2P_PORT", "8001")
         # Health check port for local collector (default: 8080, can be overridden in pre-configured env)
         final_env_vars.setdefault("LOCAL_COLLECTOR_HEALTH_CHECK_PORT", "8080")

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -283,7 +283,11 @@ def deploy_snapshotter_instance(
 
     # Add BDS-specific environment variables for BDS_DEVNET_ALPHA_UNISWAPV3
     if market_config.name.upper() == "BDS_DEVNET_ALPHA_UNISWAPV3":
-        final_env_vars["DEV_MODE"] = "true"
+        # Note: DEV_MODE not forced - user controls via namespaced env file
+        # Set DEV_MODE=true in namespaced env to build from source instead of using pre-built images
+        # For production deployments (DEV_MODE not set), use experimental tag for pre-built images
+        final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "experimental")
+        final_env_vars.setdefault("IMAGE_TAG", "experimental")
         final_env_vars.setdefault("LOCAL_COLLECTOR_P2P_PORT", "8001")
         # Health check port for local collector (default: 8080, can be overridden in pre-configured env)
         final_env_vars.setdefault("LOCAL_COLLECTOR_HEALTH_CHECK_PORT", "8080")
@@ -341,7 +345,11 @@ def deploy_snapshotter_instance(
         # PUBLIC_IP left blank for publisher role (lite nodes can run from low-powered instances)
         final_env_vars["PUBLIC_IP"] = ""
     elif market_config.name.upper() == "BDS_MAINNET_ALPHA_UNISWAPV3":
-        final_env_vars["DEV_MODE"] = "true"
+        # Note: DEV_MODE not forced - user controls via namespaced env file
+        # Set DEV_MODE=true in namespaced env to build from source instead of using pre-built images
+        # For production deployments (DEV_MODE not set), use experimental tag for pre-built images
+        final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "experimental")
+        final_env_vars.setdefault("IMAGE_TAG", "experimental")
         final_env_vars.setdefault("LOCAL_COLLECTOR_P2P_PORT", "8001")
         # Health check port for local collector (default: 8080, can be overridden in pre-configured env)
         final_env_vars.setdefault("LOCAL_COLLECTOR_HEALTH_CHECK_PORT", "8080")

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -289,15 +289,13 @@ def deploy_snapshotter_instance(
     # Add BDS-specific environment variables for BDS markets
     # Note: DEV_MODE not forced - user controls via namespaced env file
     # Set DEV_MODE=true in namespaced env to build from source instead of using pre-built images
-    # For production deployments (DEV_MODE not set), use experimental tag for pre-built images
-    # Since dev mode is not yet available for snapshotter-lite-v2, we force experimental tags for all BDS markets
+    # For production deployments (DEV_MODE not set), use pre-built images
     if market_config.name.upper() in (
         "BDS_DEVNET_ALPHA_UNISWAPV3",
         "BDS_MAINNET_UNISWAPV3",
     ):
-        # Force experimental image tags for BDS markets (dev mode not available yet)
-        final_env_vars["LOCAL_COLLECTOR_IMAGE_TAG"] = "experimental"
-        final_env_vars["IMAGE_TAG"] = "master"
+        # Default BDS local collector image tag to master (namespaced env can override)
+        final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "master")
         final_env_vars.setdefault("LOCAL_COLLECTOR_P2P_PORT", "8001")
         # Health check port for local collector (default: 8080, can be overridden in pre-configured env)
         final_env_vars.setdefault("LOCAL_COLLECTOR_HEALTH_CHECK_PORT", "8080")

--- a/snapshotter_cli/utils/models.py
+++ b/snapshotter_cli/utils/models.py
@@ -25,6 +25,10 @@ class MarketConfig(BaseModel):
     compute: ComputeConfig
     config: ComputeConfig
     bootstrapNodes: Optional[List[str]] = None  # List of bootstrap node multiaddrs
+    # P2P / mesh (optional; when set, used as defaults; namespaced env overrides)
+    rendezvousPoint: Optional[str] = None
+    gossipsubSnapshotSubmissionPrefix: Optional[str] = None
+    centralizedSequencerEnabled: Optional[str] = None  # "true" or "false"
 
 
 class PowerloomChainConfig(BaseModel):

--- a/snapshotter_cli/utils/models.py
+++ b/snapshotter_cli/utils/models.py
@@ -24,6 +24,7 @@ class MarketConfig(BaseModel):
     sequencer: str
     compute: ComputeConfig
     config: ComputeConfig
+    bootstrapNodes: Optional[List[str]] = None  # List of bootstrap node multiaddrs
 
 
 class PowerloomChainConfig(BaseModel):

--- a/snapshotter_cli/utils/models.py
+++ b/snapshotter_cli/utils/models.py
@@ -28,7 +28,7 @@ class MarketConfig(BaseModel):
     # P2P / mesh (optional; when set, used as defaults; namespaced env overrides)
     rendezvousPoint: Optional[str] = None
     gossipsubSnapshotSubmissionPrefix: Optional[str] = None
-    centralizedSequencerEnabled: Optional[str] = None  # "true" or "false"
+    centralizedSequencerEnabled: Optional[bool] = False
 
 
 class PowerloomChainConfig(BaseModel):


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [ ] I ran pre-commit checks against my changes.
- [ ] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
- BDS-DSV rollout path is incomplete (market-aware env shaping + correct `build.sh` mode flags + consistent P2P defaults).
- Deploy cannot batch multiple slot IDs from a single invocation.
- `configure` can overwrite/drop non-template keys from existing `.env-*` on re-run.
- Deployment does not propagate `sources.json` compute/config commit pins into env vars for deterministic checkout.

### New expected behaviour
- BDS-DSV markets are deployable end-to-end:
  - Correct `build.sh` mode flags for BDS (`--bds-dsv-devnet`, `--bds-dsv-mainnet`) and forced lite-node branch selection for BDS.
  - P2P/mesh defaults (rendezvous point, gossipsub submission prefix, centralized sequencer enabled) come from `sources.json` without clobbering namespaced overrides.
- Deploy supports `--slots` to deploy multiple slot IDs in one run.
- `configure` preserves non-template env keys on re-run.
- Deployment exports compute/config repo commit pins from `sources.json` when present.

### Change logs

#### Added
- `deploy --slots <comma-separated>` for multi-slot deployments.
- Support for BDS DSV markets in deploy/CLI (devnet + mainnet).
- Export `SNAPSHOTTER_COMPUTE_REPO_COMMIT` / `SNAPSHOT_CONFIG_REPO_COMMIT` from `sources.json` when present.

#### Changed
- `MARKETS_CONFIG_URL` points to `curated-datamarkets` `master`.
- P2P/mesh defaults sourced from market config (`sources.json`) instead of hardcoded values.

#### Fixed
- `configure` no longer overwrites unrelated env vars in existing `.env-*` files.

## Deployment Instructions
- Update your `snapshotter-lite-multi-setup` checkout to this rollout branch.
- Run `snapshotter configure` (repeat once) and confirm non-template keys remain intact.
- Deploy BDS using `snapshotter deploy --slots <slot1,slot2,...>` and confirm generated env includes P2P defaults and (when present) commit pin env vars.