### PR TITLE
Refactor/config prompt helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Powerloom Snapshotter CLI and setup tools will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Improved
+- **Configure command prompt UX** - Replaced confusing empty `()` brackets with explicit hints: `(required)`, `(optional, leave blank to skip)`, `(current: value, press Enter to keep)` when overwriting, and `(default: value, press Enter to use)` for built-in defaults. Makes first-time setup vs reconfiguration clearer.
+
 ## [v0.3.0] - 2026-02-24
 
 ### Added

--- a/CLI_DOCUMENTATION.md
+++ b/CLI_DOCUMENTATION.md
@@ -209,7 +209,7 @@ All regular CLI commands work in shell mode, plus:
 
 ### configure
 
-Set up credentials and settings for a specific chain and data market combination.
+Set up credentials and settings for a specific chain and data market combination. Prompts use clear hints: `(required)`, `(optional, leave blank to skip)`, `(current: value, press Enter to keep)` when reconfiguring, and `(default: value, press Enter to use)` for built-in defaults.
 
 ```bash
 powerloom-snapshotter-cli configure [OPTIONS]

--- a/docs/DSV_MAINNET_SETUP.md
+++ b/docs/DSV_MAINNET_SETUP.md
@@ -18,12 +18,15 @@ uv run powerloom-snapshotter-cli configure --env mainnet --market BDS_MAINNET_UN
 ```
 
 ```bash
-👉 Enter slot NFT holder wallet address (0x...) (): <slot NFT holder wallet address>
-👉 Enter SNAPSHOTTER signer address (0x...) (): <SNAPSHOTTER signer address>
-👉 Enter signer private key (): <signer private key>
-👉 Enter RPC URL for ETH-MAINNET (): <ETH-MAINNET RPC URL>
-👉 Enter Telegram chat ID (optional) (): <Telegram chat ID can be left blank>
-👉 Enter local collector P2P port (for gossipsub mesh communication) (8001): <local collector P2P port. Can be left blank, default is 8001>
+# First-time setup: prompts show (required) or (optional, leave blank to skip)
+# Reconfiguring: prompts show (current: value, press Enter to keep) or (default: value, press Enter to use)
+👉 Enter slot NFT holder wallet address (0x...) (required): <slot NFT holder wallet address>
+👉 Enter SNAPSHOTTER signer address (0x...) (required): <SNAPSHOTTER signer address>
+👉 Enter signer private key (required): <signer private key>
+👉 Enter RPC URL for ETH-MAINNET (required): <ETH-MAINNET RPC URL>
+👉 Enter Powerloom RPC URL (default: https://rpc-v2.powerloom.network, press Enter to use): <or press Enter>
+👉 Enter Telegram chat ID (optional, leave blank to skip): <or leave blank>
+👉 Enter local collector P2P port (for gossipsub mesh communication) (default: 8001, press Enter to use): <or press Enter>
 ✅ Created /root/.powerloom-snapshotter-cli/profiles/bds-mainnet-uniswapv3/.env.mainnet.bds_mainnet_uniswapv3.eth_mainnet with following values:
 ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Environment File Contents ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 < Your environment file contents >

--- a/snapshotter_cli/utils/console.py
+++ b/snapshotter_cli/utils/console.py
@@ -36,10 +36,14 @@ def config_prompt(
         hint = "(current: set, press Enter to keep)"
     elif has_current:
         # Truncate long values for display
-        display = current_value if len(current_value) <= 50 else current_value[:47] + "..."
+        display = (
+            current_value if len(current_value) <= 50 else current_value[:47] + "..."
+        )
         hint = f"(current: {display}, press Enter to keep)"
     elif has_builtin_default:
-        display = default_value if len(default_value) <= 60 else default_value[:57] + "..."
+        display = (
+            default_value if len(default_value) <= 60 else default_value[:57] + "..."
+        )
         hint = f"(default: {display}, press Enter to use)"
     elif optional:
         hint = "(optional, leave blank to skip)"

--- a/snapshotter_cli/utils/console.py
+++ b/snapshotter_cli/utils/console.py
@@ -12,6 +12,54 @@ from rich.console import Console as RichConsole
 from rich.prompt import Prompt as RichPrompt
 
 
+def config_prompt(
+    label: str,
+    *,
+    current_value: str = "",
+    default_value: Optional[str] = None,
+    optional: bool = False,
+    password: bool = False,
+) -> str:
+    """
+    Prompt for config values with clear first-time vs overwrite wording.
+    Avoids confusing empty () and uses explicit [current: x] / [default: x] / [required] hints.
+
+    - current_value: existing saved value (overwriting config). Empty = first-time.
+    - default_value: built-in default when no current value (e.g. "8001", Powerloom RPC URL).
+    - optional: if True, user can leave blank.
+    """
+    has_current = bool(current_value and current_value.strip())
+    has_builtin_default = default_value is not None and default_value != ""
+
+    # Use parentheses (not brackets) so hints survive Rich markup stripping in frozen builds
+    if password and has_current:
+        hint = "(current: set, press Enter to keep)"
+    elif has_current:
+        # Truncate long values for display
+        display = current_value if len(current_value) <= 50 else current_value[:47] + "..."
+        hint = f"(current: {display}, press Enter to keep)"
+    elif has_builtin_default:
+        display = default_value if len(default_value) <= 60 else default_value[:57] + "..."
+        hint = f"(default: {display}, press Enter to use)"
+    elif optional:
+        hint = "(optional, leave blank to skip)"
+    else:
+        hint = "(required)"
+
+    prompt_text = f"{label} {hint}"
+    if password and has_current:
+        effective_default = "(hidden)"  # configure.py maps this back to existing_key
+    else:
+        effective_default = current_value if has_current else (default_value or "")
+
+    return Prompt.ask(
+        prompt_text,
+        default=effective_default,
+        show_default=False,  # We embed the hint in the prompt text
+        password=password,
+    )
+
+
 def get_console() -> RichConsole:
     """
     Get a properly configured Rich Console instance.


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->
### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
Configure command prompts use Rich's default format: values in brackets like `(value)` or empty `()` when no default exists. Users often don't understand what `()` means or whether a value is current config vs built-in default.

### New expected behaviour
Prompts use explicit hints instead of raw brackets:
- `(required)` for first-time required fields
- `(optional, leave blank to skip)` for optional fields
- `(current: value, press Enter to keep)` when overwriting existing config
- `(default: value, press Enter to use)` for built-in defaults (e.g. Powerloom RPC, P2P port 8001)
- `(current: set, press Enter to keep)` for password fields with existing values

### Change logs

#### Changed
- Configure command prompt UX: `config_prompt()` helper added in `snapshotter_cli/utils/console.py`; all credential prompts in `configure.py` now use it instead of `Prompt.ask()` with raw defaults
- Documentation updated: DSV_MAINNET_SETUP.md, ai-coord-docs dsv-mainnet-lite-node-setup-instructions, CLI_DOCUMENTATION.md

## Deployment Instructions
Run `uv run powerloom-snapshotter-cli` from the latest branch or downlaod the test binaries.