### PR TITLE
Fix slot ownership validation when `--slots` are passed directly to CLI deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Slot ownership validation for `--slot`/`--slots` flags (#101)** - Deploy command now validates that explicitly provided slot IDs are owned by the wallet before deploying, matching the validation already present in the interactive path and legacy `multi_clone.py`. Previously, unowned slots passed via flags would silently attempt deployment and fail.
+
 ### Improved
 - **Configure command prompt UX** - Replaced confusing empty `()` brackets with explicit hints: `(required)`, `(optional, leave blank to skip)`, `(current: value, press Enter to keep)` when overwriting, and `(default: value, press Enter to use)` for built-in defaults. Makes first-time setup vs reconfiguration clearer.
 


### PR DESCRIPTION
Fixes #101 

## Summary

- Adds slot ownership validation for explicitly provided `--slot`/`--slots` flags in the `deploy` command, closing a gap where unowned slots could be deployed silently
- Moves protocol state contract address resolution before the slot branching logic so it's available for both the provided-slots and interactive paths
- Mirrors the validation behavior already present in the legacy `multi_clone.py` (lines 901-909)

## Problem

When slots were passed directly via `--slot` or `--slots` flags, the CLI skipped ownership validation entirely and went straight to deployment. The interactive path (no slots provided) correctly validated ownership via `fetch_owned_slots()`, but the explicit-slots path did not. This meant a user could accidentally deploy slots they don't own, wasting resources and causing silent failures.

## Changes

### `snapshotter_cli/cli.py` (+42, -7)

**Refactored** the protocol state contract address resolution out of the `if not deploy_slots` block and moved it before the branching logic, making it available for both code paths.

**Added** a new `if deploy_slots:` branch that:
1. Calls `fetch_owned_slots()` to get the wallet's actual owned slots
2. Compares provided slots against owned slots
3. Reports invalid (unowned) slots with a clear error message and exits
4. Prints confirmation when all slots pass validation

**Changed** `if not deploy_slots:` to `elif not deploy_slots:` for clean mutual exclusion between the two paths. The interactive path remains completely unchanged.

## Test plan

- [ ] Deploy with `--slots` providing **valid owned slots** — should pass validation and proceed
- [ ] Deploy with `--slots` providing **unowned slot IDs** — should display error listing invalid slots and owned slots, then exit
- [ ] Deploy with **no slots** (interactive path) — should work exactly as before (no regression)
- [ ] Deploy with `--slot` (single slot, repeated) — same validation behavior
- [ ] `uv run pytest tests/` — all 6 CLI tests pass
