### PR TITLE
Add `--force` / `-f` flag to skip slot ownership validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--force` / `-f` flag for deploy command** - Skip slot ownership validation when deploying with explicit `--slot`/`--slots` flags. Useful when deploying slots that will be transferred or when the RPC returns stale data. Available in both CLI (`powerloom-snapshotter-cli deploy --force`) and legacy script (`multi_clone.py --force`).
+
 ## [v0.3.1] - 2026-02-26
 
 ### Fixed

--- a/multi_clone.py
+++ b/multi_clone.py
@@ -784,6 +784,7 @@ def main(
     parallel_workers: int = None,
     sequential: bool = False,
     slot_list: list = None,
+    force: bool = False,
 ):
     # check if Docker is running
     if not docker_running():
@@ -900,13 +901,16 @@ def main(
         print(f"🟢 Latest-only mode: Deploying only the latest slot {latest_slot}")
     elif slot_list:
         # Deploy specific slots from provided list
-        invalid_slots = [slot for slot in slot_list if slot not in slot_ids]
-        if invalid_slots:
-            print(
-                f"❌ Error: The following slots are not owned by this wallet: {invalid_slots}"
-            )
-            print(f"Available slots: {slot_ids}")
-            sys.exit(1)
+        if not force:
+            invalid_slots = [slot for slot in slot_list if slot not in slot_ids]
+            if invalid_slots:
+                print(
+                    f"❌ Error: The following slots are not owned by this wallet: {invalid_slots}"
+                )
+                print(f"Available slots: {slot_ids}")
+                sys.exit(1)
+        else:
+            print("⚠️  Skipping slot ownership validation (--force).")
         deploy_slots = slot_list
         print(f"🟢 Slot list mode: Deploying specified slots {deploy_slots}")
     elif non_interactive:
@@ -1136,6 +1140,12 @@ if __name__ == "__main__":
         metavar="SLOT_IDS",
         help="Comma-separated list of specific slot IDs to deploy (e.g., --slots 1234,5678,9012)",
     )
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Skip slot ownership validation when using --slots",
+    )
 
     args = parser.parse_args()
 
@@ -1181,4 +1191,5 @@ if __name__ == "__main__":
         parallel_workers=args.parallel_workers,
         sequential=args.sequential,
         slot_list=slot_list,
+        force=args.force,
     )

--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -261,6 +261,9 @@ def deploy(
     signer_key_opt: Optional[str] = typer.Option(
         None, "--signer-key", help="Signer account private key.", hide_input=True
     ),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Skip slot ownership validation."
+    ),
 ):
     """Deploy snapshotter nodes for specified environment and data markets."""
     # --- Docker Check ---
@@ -635,7 +638,7 @@ def deploy(
             first_market.powerloomProtocolStateContractAddress
         )
 
-        if deploy_slots:
+        if deploy_slots and not force:
             # Validate provided slots are owned by the wallet
             console.print(
                 f"ℹ️ Validating provided slots against wallet {final_wallet_address}...",
@@ -667,6 +670,11 @@ def deploy(
             console.print(
                 "✅ All provided slots validated as owned.",
                 style="green",
+            )
+        elif deploy_slots and force:
+            console.print(
+                "⚠️  Skipping slot ownership validation (--force).",
+                style="yellow",
             )
         elif not deploy_slots:
             console.print(


### PR DESCRIPTION
## Summary

- Adds a `--force` / `-f` flag to both the CLI (`deploy` command) and legacy script (`multi_clone.py`) that skips slot ownership validation when deploying with explicit `--slot`/`--slots` flags
- v0.3.1 introduced slot ownership validation that rejects slots not owned by the wallet. This flag provides an escape hatch for legitimate use cases (e.g., deploying slots pending transfer, stale RPC data)
- When `--force` is used, a yellow warning is printed instead of running the validation

## Changes

### `snapshotter_cli/cli.py`
- Added `force: bool` Typer option (`--force` / `-f`) to the `deploy()` function signature
- Guarded the existing slot ownership validation block: skips validation and prints a warning when `--force` is set with explicit slots

### `multi_clone.py`
- Added `-f` / `--force` argparse argument
- Added `force: bool = False` parameter to `main()` function
- Guarded the `invalid_slots` check in the `slot_list` branch with the `force` flag
- Passed `force=args.force` through to `main()`

### `CHANGELOG.md`
- Added entry under `[Unreleased]` documenting the new flag

## Test plan

- [ ] `uv run powerloom-snapshotter-cli deploy --help` shows `--force` / `-f` option
- [ ] `uv run python multi_clone.py --help` shows `--force` / `-f` option
- [ ] Deploy with `--force --slots 999999` skips ownership validation and prints warning in both tools
- [ ] Deploy with `--slots` (no `--force`) still validates slot ownership as before
- [ ] Deploy without `--slots` (interactive path) is unaffected by `--force`
