### PR TITLE
Fix subsequent slots in second market submitting to wrong local collector port

### DIFF
--- a/snapshotter_cli/cli.py
+++ b/snapshotter_cli/cli.py
@@ -24,6 +24,7 @@ from .utils.deployment import (
     CONFIG_DIR,
     CONFIG_ENV_FILENAME_TEMPLATE,
     deploy_snapshotter_instance,
+    get_instance_env_file_path,
     parse_env_file_vars,
     run_git_command,
 )
@@ -1002,6 +1003,7 @@ def deploy(
                 failed_deployments += len(deploy_slots)
                 continue
 
+            collector_port_for_market = None
             for idx, slot_id_val in enumerate(deploy_slots):
                 # Build base args for build.sh
                 base_args = (
@@ -1059,9 +1061,33 @@ def deploy(
                     base_snapshotter_lite_repo_path=base_snapshotter_clone_path,
                     build_sh_args_param=build_sh_args_for_instance,
                     active_profile=active_profile,
+                    local_collector_port=collector_port_for_market,
                 )
                 if success:
                     successful_deployments += 1
+                    # After first slot deploys, read back the LOCAL_COLLECTOR_PORT
+                    # that collector_test.sh assigned (it may differ from the default
+                    # 50051 if that port was already in use by another market).
+                    # Pass this port to subsequent slots so they connect to the
+                    # correct collector for this market.
+                    if idx == 0 and len(deploy_slots) > 1:
+                        first_slot_env_path = get_instance_env_file_path(
+                            env_config.chain_config,
+                            market_conf_obj,
+                            slot_id_val,
+                        )
+                        if first_slot_env_path.exists():
+                            first_slot_env_vars = parse_env_file_vars(
+                                str(first_slot_env_path)
+                            )
+                            collector_port_for_market = first_slot_env_vars.get(
+                                "LOCAL_COLLECTOR_PORT", "50051"
+                            )
+                            console.print(
+                                f"    ℹ️ Detected LOCAL_COLLECTOR_PORT={collector_port_for_market} from first slot; "
+                                f"will use for remaining slots in this market.",
+                                style="dim",
+                            )
                 else:
                     failed_deployments += 1
                     console.print(

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -108,6 +108,25 @@ def run_os_system_command(command_str: str, instance_dir_name: str, action_desc:
         return False
 
 
+def get_instance_env_file_path(
+    powerloom_chain_config: ChainConfig,
+    market_config: MarketConfig,
+    slot_id: int,
+) -> Path:
+    """Compute the .env file path for a given chain/market/slot instance."""
+    norm_pl_chain_name = powerloom_chain_config.name.lower()
+    market_name_upper = market_config.name.upper()
+    norm_market_name = market_config.name.lower()
+    norm_source_chain_name_for_path = market_config.sourceChain.lower()
+    source_chain_prefix_upper = market_config.sourceChain.split("-")[0].upper()
+    instance_subpath = f"{norm_pl_chain_name}/{norm_market_name}_{norm_source_chain_name_for_path}/slot-{slot_id}"
+    instance_dir = SNAPSHOTTER_LITE_V2_DIR / instance_subpath
+    env_file_suffix = (
+        f"{norm_pl_chain_name}-{market_name_upper}-{source_chain_prefix_upper}"
+    )
+    return instance_dir / f".env-{env_file_suffix}"
+
+
 def deploy_snapshotter_instance(
     powerloom_chain_config: ChainConfig,  # Config for the Powerloom chain (e.g., devnet, mainnet)
     market_config: MarketConfig,  # Config for the specific data market (e.g., UNISWAPV2 on ETH-MAINNET)
@@ -120,6 +139,9 @@ def deploy_snapshotter_instance(
     active_profile: Optional[
         str
     ] = None,  # Optional profile name to load env from profile directory
+    local_collector_port: Optional[
+        str
+    ] = None,  # Port discovered by first slot's collector_test.sh
 ) -> bool:
     """
     Deploys a single snapshotter-lite-v2 instance for a given slot and market.
@@ -376,7 +398,10 @@ def deploy_snapshotter_instance(
 
     # Add missing vars from multi_clone.py, using defaults or loading from pre-config/env
     # For simplicity, pre-loaded 'final_env_vars' from a namespaced .env file can override these defaults.
-    final_env_vars.setdefault("LOCAL_COLLECTOR_PORT", "50051")
+    if local_collector_port:
+        final_env_vars["LOCAL_COLLECTOR_PORT"] = local_collector_port
+    else:
+        final_env_vars.setdefault("LOCAL_COLLECTOR_PORT", "50051")
     final_env_vars.setdefault(
         "MAX_STREAM_POOL_SIZE", "2"
     )  # Default from multi_clone, may need adjustment based on CPU as in multi_clone


### PR DESCRIPTION
Fixes #115 

## Summary

- Fix a bug where subsequent slots (idx > 0) for a second market incorrectly use `LOCAL_COLLECTOR_PORT=50051` (the first market's collector) instead of the port assigned by `collector_test.sh` for their own market
- After the first slot in a market deploys, read back the actual `LOCAL_COLLECTOR_PORT` from its `.env` file and propagate it to all subsequent slots in that market

## Problem

When deploying multiple markets with multiple slots each, only the first slot (idx=0) runs `collector_test.sh` via `build.sh`, which discovers the correct available port and updates that slot's `.env` file. Subsequent slots (idx > 0) get `--no-collector`, skip `collector_test.sh`, and their `.env` files retain the incorrect default port `50051`.

**Example (second market with slots [321, 654, 987]):**
1. Slot 321 (idx=0): `.env` gets port 50051 -> `collector_test.sh` finds 50051 taken -> updates to 50052 -> starts collector on 50052
2. Slot 654 (idx=1): `.env` gets port 50051 (default) -> `--no-collector` skips port discovery -> node connects to port 50051 (wrong market!)
3. Slot 987 (idx=2): Same problem as slot 654

## Changes

### `snapshotter_cli/utils/deployment.py`
- Added `get_instance_env_file_path()` helper that computes the `.env` file path for a given chain/market/slot, extracting the path computation logic already present in `deploy_snapshotter_instance()`
- Added `local_collector_port` optional parameter to `deploy_snapshotter_instance()` — when provided, force-sets `LOCAL_COLLECTOR_PORT` instead of using the default `50051`

### `snapshotter_cli/cli.py`
- Import `get_instance_env_file_path` from deployment utils
- Initialize `collector_port_for_market = None` before each market's slot loop (resets per market)
- After first slot (idx=0) deploys successfully and 10s sleep completes, read back the `.env` file to get the actual `LOCAL_COLLECTOR_PORT` that `collector_test.sh` assigned
- Pass `local_collector_port=collector_port_for_market` to all subsequent `deploy_snapshotter_instance()` calls

## Why This Works

- `collector_test.sh` runs early in `build.sh` and updates the `.env` file via `sed -i` before docker-compose starts
- The 10-second sleep after launching the first slot provides ample time for `collector_test.sh` to finish
- For subsequent slots, we explicitly set the correct port in their `.env` files, bypassing the stale default

## Scope

- **CLI only** — `multi_clone.py` has the same bug but is legacy/slated for deprecation

## Test Plan

- [ ] Deploy a first market with multiple slots: `deploy --env mainnet --market UNISWAPV2 --slots 123,456`
- [ ] Deploy a second market with multiple slots: `deploy --env mainnet --market AAVEV3 --slots 789,012`
- [ ] Verify all slots of the second market have the correct `LOCAL_COLLECTOR_PORT` in their `.env` files (should all match, e.g., 50052)
- [ ] Check docker containers to confirm nodes connect to the correct collector
- [ ] Verify single-slot deployments still work correctly (no regression)
