### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -86,6 +86,16 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "**/uv.lock"
 
+    - name: Verify release tag matches pyproject.toml version
+      if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')
+      run: |
+        TAG_VER="${GITHUB_REF_NAME#v}"
+        PKG_VER=$(grep '^version = ' pyproject.toml | sed -n 's/version = "\([^"]*\)"/\1/p')
+        if [ "$TAG_VER" != "$PKG_VER" ]; then
+          echo "::error::Git ref is ${GITHUB_REF_NAME} but pyproject.toml version is ${PKG_VER}. Bump pyproject.toml before publishing."
+          exit 1
+        fi
+
     - name: Set version for TestPyPI
       if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/develop')) && !startsWith(github.ref, 'refs/tags/')
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **PyPI publish for the v0.4.0 GitHub release** — The release workflow builds wheels/sdist from `pyproject.toml`; that file still listed **0.3.1**, so uploads targeted an already-published version and failed. Package version is now **0.4.1** with **`uv.lock`** in sync.
 - **BDS default `LOCAL_COLLECTOR_IMAGE_TAG`** — `configure` wrote **`latest`** into profile `.env` for every market; `deployment` only used `setdefault("master")`, so the profile value won and Compose pulled the wrong GHCR tag. BDS markets now default **`master`** in `configure`, **`latest` is no longer applied** as a generic fallback for BDS in `deployment`, and deploy **normalizes** empty/`latest` → **`master`** for `IMAGE_TAG` and `LOCAL_COLLECTOR_IMAGE_TAG` so existing profiles fix themselves on the next deploy. Non-BDS markets keep **`latest`** for the local collector when unset.
+- **Import order in `configure.py`** — `isort --check` on CI failed after adding `BDS_DATA_MARKET_NAMES`; imports sorted for `black`/`isort` profile.
 
 ### Added
 - **`publish-pypi.yml` release guard** — On `release` or `refs/tags/v*`, CI fails if the tag name (without leading `v`) does not match `version` in `pyproject.toml`, so tag and package version cannot diverge before `uv build`.
 
 ### Changed
-- **`docs/DSV_MAINNET_SETUP.md`** — Pre-built binary example URLs point at **v0.4.1** (match the GitHub release tag you install).
+- **`docs/DSV_MAINNET_SETUP.md`** — Pre-built binary example URLs point at **v0.4.1**; sample install verification line shows CLI **0.4.1**.
 
 ## [v0.4.0] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **PyPI publish for the v0.4.0 GitHub release** — The release workflow builds wheels/sdist from `pyproject.toml`; that file still listed **0.3.1**, so uploads targeted an already-published version and failed. Package version is now **0.4.1** with **`uv.lock`** in sync.
+- **BDS default `LOCAL_COLLECTOR_IMAGE_TAG`** — `configure` wrote **`latest`** into profile `.env` for every market; `deployment` only used `setdefault("master")`, so the profile value won and Compose pulled the wrong GHCR tag. BDS markets now default **`master`** in `configure`, **`latest` is no longer applied** as a generic fallback for BDS in `deployment`, and deploy **normalizes** empty/`latest` → **`master`** for `IMAGE_TAG` and `LOCAL_COLLECTOR_IMAGE_TAG` so existing profiles fix themselves on the next deploy. Non-BDS markets keep **`latest`** for the local collector when unset.
 
 ### Added
 - **`publish-pypi.yml` release guard** — On `release` or `refs/tags/v*`, CI fails if the tag name (without leading `v`) does not match `version` in `pyproject.toml`, so tag and package version cannot diverge before `uv build`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Powerloom Snapshotter CLI and setup tools will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.1] - 2026-05-13
+
+### Fixed
+- **PyPI publish for the v0.4.0 GitHub release** — The release workflow builds wheels/sdist from `pyproject.toml`; that file still listed **0.3.1**, so uploads targeted an already-published version and failed. Package version is now **0.4.1** with **`uv.lock`** in sync.
+
+### Added
+- **`publish-pypi.yml` release guard** — On `release` or `refs/tags/v*`, CI fails if the tag name (without leading `v`) does not match `version` in `pyproject.toml`, so tag and package version cannot diverge before `uv build`.
+
+### Changed
+- **`docs/DSV_MAINNET_SETUP.md`** — Pre-built binary example URLs point at **v0.4.1** (match the GitHub release tag you install).
+
 ## [v0.4.0] - 2026-05-13
 
 ### Fixed
@@ -176,6 +187,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[v0.4.1]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.4.1
+[v0.4.0]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.4.0
 [v0.3.1]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.3.1
 [v0.3.0]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.3.0
 [v0.2.0]: https://github.com/powerloom/snapshotter-lite-multi-setup/releases/tag/v0.2.0

--- a/docs/DSV_MAINNET_SETUP.md
+++ b/docs/DSV_MAINNET_SETUP.md
@@ -202,9 +202,9 @@ Head to the latest [release page](https://github.com/powerloom/snapshotter-lite-
 
 The typical installation path is to copy the downloaded binary to `/usr/local/bin/powerloom-snapshotter-cli` or `/usr/local/bin/snapshotter` and make it executable.
 
-For example, if you are on an x86_64 Linux machine and `v0.3.1` is the latest release, these would be the commands to install the CLI:
+For example, if you are on an x86_64 Linux machine and `v0.4.0` is the latest release, these would be the commands to install the CLI:
 ```bash
-wget https://github.com/powerloom/snapshotter-lite-multi-setup/releases/download/v0.3.1/powerloom-snapshotter-cli-linux-amd64
+wget https://github.com/powerloom/snapshotter-lite-multi-setup/releases/download/v0.4.0/powerloom-snapshotter-cli-linux-amd64
 chmod +x powerloom-snapshotter-cli-linux-amd64
 sudo mv powerloom-snapshotter-cli-linux-amd64 /usr/local/bin/powerloom-snapshotter-cli
 ```

--- a/docs/DSV_MAINNET_SETUP.md
+++ b/docs/DSV_MAINNET_SETUP.md
@@ -202,9 +202,9 @@ Head to the latest [release page](https://github.com/powerloom/snapshotter-lite-
 
 The typical installation path is to copy the downloaded binary to `/usr/local/bin/powerloom-snapshotter-cli` or `/usr/local/bin/snapshotter` and make it executable.
 
-For example, if you are on an x86_64 Linux machine and `v0.4.0` is the latest release, these would be the commands to install the CLI:
+For example, if you are on an x86_64 Linux machine and `v0.4.1` is the latest release, these would be the commands to install the CLI:
 ```bash
-wget https://github.com/powerloom/snapshotter-lite-multi-setup/releases/download/v0.4.0/powerloom-snapshotter-cli-linux-amd64
+wget https://github.com/powerloom/snapshotter-lite-multi-setup/releases/download/v0.4.1/powerloom-snapshotter-cli-linux-amd64
 chmod +x powerloom-snapshotter-cli-linux-amd64
 sudo mv powerloom-snapshotter-cli-linux-amd64 /usr/local/bin/powerloom-snapshotter-cli
 ```

--- a/docs/DSV_MAINNET_SETUP.md
+++ b/docs/DSV_MAINNET_SETUP.md
@@ -253,7 +253,7 @@ Installing from source...
 
 Verifying installation...
 ✅ Installation successful!
-Version: Powerloom Snapshotter CLI version: 0.2.0 (pip)
+Version: Powerloom Snapshotter CLI version: 0.4.1 (pip)
 
 ✅ Installation complete!
 

--- a/multi_clone.py
+++ b/multi_clone.py
@@ -132,7 +132,9 @@ def generate_env_file_contents(data_market_namespace: str, **kwargs) -> str:
         max_stream_pool_size=kwargs["max_stream_pool_size"],
         stream_pool_health_check_interval=kwargs["stream_pool_health_check_interval"],
         local_collector_image_tag=kwargs["local_collector_image_tag"],
-        telegram_notification_cooldown=kwargs.get("telegram_notification_cooldown", 300),
+        telegram_notification_cooldown=kwargs.get(
+            "telegram_notification_cooldown", 300
+        ),
         telegram_missed_batch_size=kwargs.get("telegram_missed_batch_size", 10),
         connection_refresh_interval_sec=kwargs["connection_refresh_interval_sec"],
         override_defaults=kwargs.get("override_defaults", "false"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "powerloom-snapshotter-cli"
-version = "0.3.1"
+version = "0.4.1"
 description = "CLI tool for deploying and managing Powerloom Snapshotter nodes"
 authors = [{name = "Powerloom Protocol", email = "hello@powerloom.io"}]
 readme = "PYPI_README.md"

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -12,6 +12,7 @@ from snapshotter_cli.utils.deployment import (
     CONFIG_DIR,
     CONFIG_ENV_FILENAME_TEMPLATE,
     calculate_connection_refresh_interval,
+    BDS_DATA_MARKET_NAMES,
 )
 from snapshotter_cli.utils.models import CLIContext, MarketConfig, PowerloomChainConfig
 
@@ -414,9 +415,13 @@ def configure_command(
     if final_local_collector_p2p_port:
         final_env_vars["LOCAL_COLLECTOR_P2P_PORT"] = final_local_collector_p2p_port
 
-    # Set default values for LITE_NODE_BRANCH and LOCAL_COLLECTOR_IMAGE_TAG if not present
-    final_env_vars.setdefault("LITE_NODE_BRANCH", "main")
-    final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "latest")
+    # BDS: GHCR images track `master` / branches; `latest` is wrong for lite-v2 + local-collector on GHCR.
+    if selected_market_obj.name.upper() in BDS_DATA_MARKET_NAMES:
+        final_env_vars.setdefault("LITE_NODE_BRANCH", "master")
+        final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "master")
+    else:
+        final_env_vars.setdefault("LITE_NODE_BRANCH", "main")
+        final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "latest")
     if final_env_vars.get("TELEGRAM_CHAT_ID"):
         final_env_vars.setdefault("TELEGRAM_NOTIFICATION_COOLDOWN", "300")
         final_env_vars.setdefault("TELEGRAM_MISSED_BATCH_SIZE", "10")

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -9,10 +9,10 @@ from rich.panel import Panel
 
 from snapshotter_cli.utils.console import Prompt, config_prompt, console
 from snapshotter_cli.utils.deployment import (
+    BDS_DATA_MARKET_NAMES,
     CONFIG_DIR,
     CONFIG_ENV_FILENAME_TEMPLATE,
     calculate_connection_refresh_interval,
-    BDS_DATA_MARKET_NAMES,
 )
 from snapshotter_cli.utils.models import CLIContext, MarketConfig, PowerloomChainConfig
 

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -27,6 +27,18 @@ CLI_CONFIG_DIR = Path.home() / ".powerloom-snapshotter-cli"
 PROFILES_DIR = CLI_CONFIG_DIR / "profiles"
 DEFAULT_PROFILE = "default"
 
+# BDS DSV markets: GHCR tags are `master` / branch names — not Docker Hub `latest`.
+BDS_DATA_MARKET_NAMES = frozenset(
+    {
+        "BDS_DEVNET_ALPHA_UNISWAPV3",
+        "BDS_MAINNET_UNISWAPV3",
+    },
+)
+
+
+def is_bds_market(market_name: str) -> bool:
+    return market_name.upper() in BDS_DATA_MARKET_NAMES
+
 
 def parse_env_file_vars(file_path: str) -> Dict[str, str]:
     """Parses a .env file and returns a dictionary of key-value pairs."""
@@ -355,10 +367,7 @@ def deploy_snapshotter_instance(
     # Note: DEV_MODE not forced - user controls via namespaced env file
     # Set DEV_MODE=true in namespaced env to build from source instead of using pre-built images
     # For production deployments (DEV_MODE not set), use pre-built images
-    if market_config.name.upper() in (
-        "BDS_DEVNET_ALPHA_UNISWAPV3",
-        "BDS_MAINNET_UNISWAPV3",
-    ):
+    if is_bds_market(market_config.name):
         # BDS: default GHCR tags to master if unset; profile namespaced .env must win (same as LITE_NODE_BRANCH).
         # Previously forced "master" here and overwrote IMAGE_TAG from profile .env.
         final_env_vars.setdefault("IMAGE_TAG", "master")
@@ -443,12 +452,22 @@ def deploy_snapshotter_instance(
     if "STREAM_POOL_HEALTH_CHECK_INTERVAL" not in final_env_vars:
         final_env_vars["STREAM_POOL_HEALTH_CHECK_INTERVAL"] = "60000"
     final_env_vars.setdefault("DATA_MARKET_IN_REQUEST", "false")
-    final_env_vars.setdefault(
-        "LOCAL_COLLECTOR_IMAGE_TAG", "latest"
-    )  # Simplified default
+    # Non-BDS: local collector has historically used `latest`; BDS uses GHCR `master` (see block above + normalize below)
+    if not is_bds_market(market_config.name):
+        final_env_vars.setdefault(
+            "LOCAL_COLLECTOR_IMAGE_TAG", "latest"
+        )  # legacy non-BDS
     final_env_vars.setdefault("CONNECTION_REFRESH_INTERVAL_SEC", "60")
     final_env_vars.setdefault("TELEGRAM_NOTIFICATION_COOLDOWN", "300")
     final_env_vars.setdefault("TELEGRAM_MISSED_BATCH_SIZE", "10")
+
+    # `configure` used to seed LOCAL_COLLECTOR_IMAGE_TAG=latest for all markets; namespaced .env then
+    # prevented BDS setdefault("master") from applying. Normalize empty/latest → master for BDS only.
+    if is_bds_market(market_config.name):
+        for _img_key in ("IMAGE_TAG", "LOCAL_COLLECTOR_IMAGE_TAG"):
+            _v = (final_env_vars.get(_img_key) or "").strip().lower()
+            if _v in ("", "latest"):
+                final_env_vars[_img_key] = "master"
 
     # Normalize boolean env vars to lowercase AFTER all values are set
     # This handles cases where env files have "False" or "True" instead of "false" or "true"

--- a/tests/test_deployment_repo_env.py
+++ b/tests/test_deployment_repo_env.py
@@ -21,7 +21,10 @@ def test_snapshot_config_applies_full_bundle_when_repo_unset():
             commit="abc123",
         ),
     )
-    assert env["SNAPSHOT_CONFIG_REPO"] == "https://github.com/PowerLoom/snapshotter-configs.git"
+    assert (
+        env["SNAPSHOT_CONFIG_REPO"]
+        == "https://github.com/PowerLoom/snapshotter-configs.git"
+    )
     assert env["SNAPSHOT_CONFIG_REPO_BRANCH"] == "eth_main"
     assert env["SNAPSHOT_CONFIG_REPO_COMMIT"] == "abc123"
 
@@ -37,16 +40,23 @@ def test_snapshot_config_repo_override_skips_curated_branch_and_commit():
             commit="deadbeef",
         ),
     )
-    assert env == {"SNAPSHOT_CONFIG_REPO": "https://github.com/myteam/custom-config.git"}
+    assert env == {
+        "SNAPSHOT_CONFIG_REPO": "https://github.com/myteam/custom-config.git"
+    }
 
 
 def test_compute_repo_applies_full_bundle_when_repo_unset():
     env: dict[str, str] = {}
     apply_compute_repo_from_market(
         env,
-        _cfg("https://github.com/PowerLoom/snapshotter-computes.git", "main", commit=None),
+        _cfg(
+            "https://github.com/PowerLoom/snapshotter-computes.git", "main", commit=None
+        ),
     )
-    assert env["SNAPSHOTTER_COMPUTE_REPO"] == "https://github.com/PowerLoom/snapshotter-computes.git"
+    assert (
+        env["SNAPSHOTTER_COMPUTE_REPO"]
+        == "https://github.com/PowerLoom/snapshotter-computes.git"
+    )
     assert env["SNAPSHOTTER_COMPUTE_REPO_BRANCH"] == "main"
     assert "SNAPSHOTTER_COMPUTE_REPO_COMMIT" not in env
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <3.14"
 
 [[package]]
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "powerloom-snapshotter-cli"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "psutil" },

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "powerloom-snapshotter-cli"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "psutil" },


### PR DESCRIPTION

<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

### Fixes
- PyPI: **`pyproject.toml`** stayed **0.3.1** while releasing **v0.4.x** → wheels were **0.3.1**, upload failed (version already on PyPI). **`0.4.0` never shipped** to PyPI (index still topped out at **0.3.1** until this bump).
- BDS: **`configure`** wrote **`LOCAL_COLLECTOR_IMAGE_TAG=latest`** into profile `.env`; **`deployment`** only **`setdefault("master")`**, so **`latest` stuck** → wrong GHCR tag.

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### New expected behaviour
- **`pyproject.toml` + `uv.lock`** match the tag you publish (e.g. **0.4.1**).
- **CI:** tag name (no `v`) must match **`pyproject.toml` version** before `uv build`.
- **BDS:** **`configure`** defaults **`LITE_NODE_BRANCH` / `LOCAL_COLLECTOR_IMAGE_TAG`** → **`master`**; **`deployment`** normalizes empty / **`latest`** → **`master`** (non-BDS keeps **`latest`** when unset). Custom tags (e.g. **`experimental`**) untouched.
- **Docs / CHANGELOG** updated for this release.

**Before merge:** run `uv lock` so `uv.lock` matches `pyproject.toml` (currently ensure both agree on **0.4.1** or your chosen version).

### Change logs

#### Added
- PyPI workflow step: **verify Git tag / release ref matches `pyproject.toml` version** before `uv build` on `release` or version tags.
- v0.4.0 (per `CHANGELOG.md`): custom snapshot/config + compute **profile repo overrides**; **Telegram** `TELEGRAM_NOTIFICATION_COOLDOWN` and `TELEGRAM_MISSED_BATCH_SIZE` parity with snapshotter-lite-v2 across deployment, templates, configure, profile export; **`--force` / `-f`** deploy documentation.

#### Changed
- **Package version** in `pyproject.toml` (and lockfile when synced) for a successful PyPI artifact.
- **`deployment.py`:** `BDS_DATA_MARKET_NAMES` / `is_bds_market()`; non-BDS-only default for **`LOCAL_COLLECTOR_IMAGE_TAG`** = **`latest`**; BDS normalization of **`IMAGE_TAG` / `LOCAL_COLLECTOR_IMAGE_TAG`** after env merge.
- **`configure.py`:** BDS defaults **`LITE_NODE_BRANCH`** / **`LOCAL_COLLECTOR_IMAGE_TAG`** = **`master`** (non-BDS unchanged: **`main`** / **`latest`**).
- **Docs** (`DSV_MAINNET_SETUP.md`): example `wget` URL uses the release version in the doc (e.g. v0.4.0 or v0.4.1 — keep aligned with the tag you publish).

#### Fixed
- **BDS deploy:** `LITE_NODE_BRANCH` and **`IMAGE_TAG` / `LOCAL_COLLECTOR_IMAGE_TAG`** no longer overwritten by `master` after profile `.env` merge (`setdefault` / precedence fixes in `deployment.py`).
- **BDS default local-collector tag:** **`configure`** no longer pins **`latest`** for BDS; **`deployment`** fixes legacy profiles that still have **`latest`** or empty.
- **Fork / config repos:** profile **`SNAPSHOT_CONFIG_REPO`** / **`SNAPSHOTTER_COMPUTE_REPO`** prevents injecting unrelated curated-datamarkets branch/commit from `sources.json`; coupled defaults from market JSON when URLs unset.
- **PyPI:** package version aligned with release so uploads are not duplicate **0.3.1** artifacts.

#### Improved
- **Multi-market deploy:** CLI warns when profiles use different **`LITE_NODE_BRANCH`** (shared base clone uses first market’s namespaced `.env`).

#### Removed
- N/A

## Deployment Instructions
N/A
