### PR TITLE
env coercion and substitution for cleaner configurations and deployments for BDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Powerloom Snapshotter CLI and setup tools will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`POWERLOOM_CLI_CUSTOM_LITE_IMAGES`** — Set to `1` / `true` / `yes` / `on` in the **namespaced profile** `.env` to skip BDS `IMAGE_TAG` / `LOCAL_COLLECTOR_IMAGE_TAG` `master` setdefaults, skip BDS-mainnet coercion of `LITE_NODE_BRANCH` / image tags to `master`, and skip auto `LOCAL_COLLECTOR_IMAGE_TAG` defaults for BDS markets (set `IMAGE_TAG`, `LOCAL_COLLECTOR_IMAGE_TAG`, and `LITE_NODE_BRANCH` explicitly when testing a pre-release branch). The variable is **removed** from the generated instance `.env` so it is not passed through to Compose.
+
 ## [v0.4.1] - 2026-05-13
 
 ### Fixed

--- a/snapshotter_cli/commands/configure.py
+++ b/snapshotter_cli/commands/configure.py
@@ -9,7 +9,6 @@ from rich.panel import Panel
 
 from snapshotter_cli.utils.console import Prompt, config_prompt, console
 from snapshotter_cli.utils.deployment import (
-    BDS_DATA_MARKET_NAMES,
     CONFIG_DIR,
     CONFIG_ENV_FILENAME_TEMPLATE,
     calculate_connection_refresh_interval,
@@ -415,13 +414,9 @@ def configure_command(
     if final_local_collector_p2p_port:
         final_env_vars["LOCAL_COLLECTOR_P2P_PORT"] = final_local_collector_p2p_port
 
-    # BDS: GHCR images track `master` / branches; `latest` is wrong for lite-v2 + local-collector on GHCR.
-    if selected_market_obj.name.upper() in BDS_DATA_MARKET_NAMES:
-        final_env_vars.setdefault("LITE_NODE_BRANCH", "master")
-        final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "master")
-    else:
-        final_env_vars.setdefault("LITE_NODE_BRANCH", "main")
-        final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "latest")
+    # GHCR lite-v2 / local-collector tags track `master` (and named branches), not `latest` / `main`.
+    final_env_vars.setdefault("LITE_NODE_BRANCH", "master")
+    final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "master")
     if final_env_vars.get("TELEGRAM_CHAT_ID"):
         final_env_vars.setdefault("TELEGRAM_NOTIFICATION_COOLDOWN", "300")
         final_env_vars.setdefault("TELEGRAM_MISSED_BATCH_SIZE", "10")

--- a/snapshotter_cli/commands/profile.py
+++ b/snapshotter_cli/commands/profile.py
@@ -349,6 +349,7 @@ def export_profile_command(
                 "CONNECTION_REFRESH_INTERVAL_SEC",
                 "LITE_NODE_BRANCH",
                 "LOCAL_COLLECTOR_IMAGE_TAG",
+                "POWERLOOM_CLI_CUSTOM_LITE_IMAGES",
                 "POWERLOOM_RPC_URL",
                 "TELEGRAM_REPORTING_URL",
             ]

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -475,9 +475,10 @@ def deploy_snapshotter_instance(
     if "STREAM_POOL_HEALTH_CHECK_INTERVAL" not in final_env_vars:
         final_env_vars["STREAM_POOL_HEALTH_CHECK_INTERVAL"] = "60000"
     final_env_vars.setdefault("DATA_MARKET_IN_REQUEST", "false")
-    if is_bds_mainnet_deployment(
-        market_config.name, powerloom_chain_config.name
-    ) and not _custom_lite_images:
+    if (
+        is_bds_mainnet_deployment(market_config.name, powerloom_chain_config.name)
+        and not _custom_lite_images
+    ):
         final_env_vars.setdefault(
             "LOCAL_COLLECTOR_IMAGE_TAG", "master"
         )  # GHCR :master for BDS mainnet
@@ -490,9 +491,10 @@ def deploy_snapshotter_instance(
     final_env_vars.setdefault("TELEGRAM_MISSED_BATCH_SIZE", "10")
 
     # BDS mainnet only: legacy profile/templates sometimes had `main`/`latest`; coerce to GHCR `master`.
-    if is_bds_mainnet_deployment(
-        market_config.name, powerloom_chain_config.name
-    ) and not _custom_lite_images:
+    if (
+        is_bds_mainnet_deployment(market_config.name, powerloom_chain_config.name)
+        and not _custom_lite_images
+    ):
         _lb = (final_env_vars.get("LITE_NODE_BRANCH") or "").strip().lower()
         if _lb in ("", "main", "latest"):
             final_env_vars["LITE_NODE_BRANCH"] = "master"

--- a/snapshotter_cli/utils/deployment.py
+++ b/snapshotter_cli/utils/deployment.py
@@ -40,6 +40,26 @@ def is_bds_market(market_name: str) -> bool:
     return market_name.upper() in BDS_DATA_MARKET_NAMES
 
 
+def is_bds_mainnet_deployment(market_name: str, pl_chain_name: str) -> bool:
+    """BDS DSV mainnet only — used for GHCR `master` image defaults / legacy tag normalization on deploy."""
+    return (
+        market_name.upper() == "BDS_MAINNET_UNISWAPV3"
+        and pl_chain_name.upper() == "MAINNET"
+    )
+
+
+# Profile namespaced `.env` only: when truthy, deploy skips BDS GHCR `master` image setdefaults and
+# BDS-mainnet branch/tag coercion so pre-release branches/tags are not overwritten each deploy.
+# Stripped from generated instance `.env` (not passed to containers).
+CUSTOM_LITE_IMAGES_ENV_KEY = "POWERLOOM_CLI_CUSTOM_LITE_IMAGES"
+
+
+def env_truthy(val: Optional[str]) -> bool:
+    if val is None:
+        return False
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
 def parse_env_file_vars(file_path: str) -> Dict[str, str]:
     """Parses a .env file and returns a dictionary of key-value pairs."""
     env_vars = {}
@@ -346,6 +366,8 @@ def deploy_snapshotter_instance(
     )
     final_env_vars["SOURCE_RPC_URL"] = source_chain_rpc_url
 
+    _custom_lite_images = env_truthy(final_env_vars.get(CUSTOM_LITE_IMAGES_ENV_KEY))
+
     # Apply mesh/P2P defaults from market config when present (namespaced env still wins)
     if market_config.rendezvousPoint:
         final_env_vars.setdefault("RENDEZVOUS_POINT", market_config.rendezvousPoint)
@@ -370,8 +392,9 @@ def deploy_snapshotter_instance(
     if is_bds_market(market_config.name):
         # BDS: default GHCR tags to master if unset; profile namespaced .env must win (same as LITE_NODE_BRANCH).
         # Previously forced "master" here and overwrote IMAGE_TAG from profile .env.
-        final_env_vars.setdefault("IMAGE_TAG", "master")
-        final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "master")
+        if not _custom_lite_images:
+            final_env_vars.setdefault("IMAGE_TAG", "master")
+            final_env_vars.setdefault("LOCAL_COLLECTOR_IMAGE_TAG", "master")
         final_env_vars.setdefault("LOCAL_COLLECTOR_P2P_PORT", "8001")
         # Health check port for local collector (default: 8080, can be overridden in pre-configured env)
         final_env_vars.setdefault("LOCAL_COLLECTOR_HEALTH_CHECK_PORT", "8080")
@@ -452,18 +475,27 @@ def deploy_snapshotter_instance(
     if "STREAM_POOL_HEALTH_CHECK_INTERVAL" not in final_env_vars:
         final_env_vars["STREAM_POOL_HEALTH_CHECK_INTERVAL"] = "60000"
     final_env_vars.setdefault("DATA_MARKET_IN_REQUEST", "false")
-    # Non-BDS: local collector has historically used `latest`; BDS uses GHCR `master` (see block above + normalize below)
-    if not is_bds_market(market_config.name):
+    if is_bds_mainnet_deployment(
+        market_config.name, powerloom_chain_config.name
+    ) and not _custom_lite_images:
+        final_env_vars.setdefault(
+            "LOCAL_COLLECTOR_IMAGE_TAG", "master"
+        )  # GHCR :master for BDS mainnet
+    elif not (is_bds_market(market_config.name) and _custom_lite_images):
         final_env_vars.setdefault(
             "LOCAL_COLLECTOR_IMAGE_TAG", "latest"
-        )  # legacy non-BDS
+        )  # legacy non-BDS; BDS devnet keeps tag from block above unless custom (then set in profile)
     final_env_vars.setdefault("CONNECTION_REFRESH_INTERVAL_SEC", "60")
     final_env_vars.setdefault("TELEGRAM_NOTIFICATION_COOLDOWN", "300")
     final_env_vars.setdefault("TELEGRAM_MISSED_BATCH_SIZE", "10")
 
-    # `configure` used to seed LOCAL_COLLECTOR_IMAGE_TAG=latest for all markets; namespaced .env then
-    # prevented BDS setdefault("master") from applying. Normalize empty/latest → master for BDS only.
-    if is_bds_market(market_config.name):
+    # BDS mainnet only: legacy profile/templates sometimes had `main`/`latest`; coerce to GHCR `master`.
+    if is_bds_mainnet_deployment(
+        market_config.name, powerloom_chain_config.name
+    ) and not _custom_lite_images:
+        _lb = (final_env_vars.get("LITE_NODE_BRANCH") or "").strip().lower()
+        if _lb in ("", "main", "latest"):
+            final_env_vars["LITE_NODE_BRANCH"] = "master"
         for _img_key in ("IMAGE_TAG", "LOCAL_COLLECTOR_IMAGE_TAG"):
             _v = (final_env_vars.get(_img_key) or "").strip().lower()
             if _v in ("", "latest"):
@@ -481,6 +513,14 @@ def deploy_snapshotter_instance(
         if var in final_env_vars:
             # Convert to string first (handles bool values from market_config), then lowercase
             final_env_vars[var] = str(final_env_vars[var]).lower()
+
+    final_env_vars.pop(CUSTOM_LITE_IMAGES_ENV_KEY, None)
+    if _custom_lite_images:
+        console.print(
+            f"  ℹ️ Custom lite images: skipping BDS `master` defaults and mainnet branch/tag coercion "
+            f"({CUSTOM_LITE_IMAGES_ENV_KEY} in profile .env).",
+            style="dim",
+        )
 
     # TELEGRAM_REPORTING_URL and TELEGRAM_CHAT_ID will be included if they were in the pre-configured .env
     # or global env vars that got loaded into namespaced_env_content (passed to get_credential originally).


### PR DESCRIPTION

<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #130 


### Checklist
- [ ] My branch is up-to-date with upstream/main branch.
- [ ] Everything works and tested for major version of Python/NodeJS/Go and above.
- [ ] I ran pre-commit checks against my changes.
- [ ] I've written tests against my changes and all the current present tests are passing.

### Current behaviour

On **BDS mainnet**, `deploy_snapshotter_instance` always applies BDS **`master`** `setdefault`s for `IMAGE_TAG` / `LOCAL_COLLECTOR_IMAGE_TAG`, then (for mainnet only) **coerces** legacy `LITE_NODE_BRANCH` and image tags toward **`master`**. That makes production defaults predictable but **reapplies on every deploy**, so operators testing a **pre-release lite/collector branch or tag** can see values normalized away when templates or empty keys interact with coercion.

### New expected behaviour

Namespaced **profile** `.env` may set **`POWERLOOM_CLI_CUSTOM_LITE_IMAGES`** to a truthy value (`1`, `true`, `yes`, `on`). When set:

- BDS **`master`** image tag **`setdefault`s are skipped** for `IMAGE_TAG` and `LOCAL_COLLECTOR_IMAGE_TAG`.
- **BDS-mainnet coercion** of branch / image tags to **`master`** is **skipped**.
- **BDS** markets do not get the `LOCAL_COLLECTOR_IMAGE_TAG` **`latest`** fallback path while custom mode is on — operators set **`LITE_NODE_BRANCH`**, **`IMAGE_TAG`**, and **`LOCAL_COLLECTOR_IMAGE_TAG`** explicitly for the test cut.

The meta key is **removed** from the generated instance `.env` (not passed to Compose). **`profile export`** includes `POWERLOOM_CLI_CUSTOM_LITE_IMAGES` in safe keys.

### Change logs

#### Added
- **`POWERLOOM_CLI_CUSTOM_LITE_IMAGES`** — profile-only override for deploy semantics above (`snapshotter_cli/utils/deployment.py`: `CUSTOM_LITE_IMAGES_ENV_KEY`, `env_truthy`, gating around BDS defaults, mainnet coercion, collector tag fallback; strip before write + dim console line when active).
- **`CHANGELOG.md`** — **`[Unreleased]`** section documents the flag and behavior.

#### Changed
- **`snapshotter_cli/commands/profile.py`** — `POWERLOOM_CLI_CUSTOM_LITE_IMAGES` added to `profile export` `safe_keys`.

#### Fixed
- _(Optional if you frame the PR as fixing "cannot test branch without deploy overwriting")_ — Pre-release BDS-mainnet image/branch testing no longer forced to **`master`** when the override is enabled.

#### Removed
- N/A

## Deployment Instructions

- No server/VPS rollout beyond **publishing a new CLI version** (PyPI / GitHub release) when you cut the release that includes this PR; **`[Unreleased]`** in `CHANGELOG.md` should be retitled to the new tag as part of that release PR or follow-up.
- **Operators**: add to the **namespaced profile** `.env` (not the generated instance `.env`):

  ```env
  POWERLOOM_CLI_CUSTOM_LITE_IMAGES=1
  LITE_NODE_BRANCH=<branch-or-tag>
  IMAGE_TAG=<matching-tag>
  LOCAL_COLLECTOR_IMAGE_TAG=<matching-tag>
  ```

  Then run **`deploy`** as usual. Remove or unset the override when returning to production **`master`** defaults.
